### PR TITLE
Emergency chunk lookup WIP

### DIFF
--- a/src/ccow/src/libccow/ccow-dynamic-fetch.c
+++ b/src/ccow/src/libccow/ccow-dynamic-fetch.c
@@ -281,6 +281,7 @@ build_isgw_service_table(ccow_t cl, struct isgw_service_entry** ptable) {
 		int MD_only_iswg = 0;
 		char* addr_str = NULL;
 		uint64_t suid = 0;
+		int dfetch_mode = eIsgwFTypeMDOnly;
 		while ((bkv = ccow_lookup_iter(biter, CCOW_MDTYPE_CUSTOM, bpos++))) {
 			char *id = (char *)bkv->key;
 			uint16_t id_size = bkv->key_size;
@@ -294,6 +295,8 @@ build_isgw_service_table(ccow_t cl, struct isgw_service_entry** ptable) {
 				MD_only_iswg++;
 			} else if (!strcmp(id, "X-ISGW-Remote-SegID") && strcmp(value, "-"))
 				suid = strtoull(value, NULL, 16);
+			else if (!strcmp(id, "X-ISGW-Emergency-Lookup") && strcmp(value, "-"))
+				dfetch_mode = eIsgwFTypeFull;
 		}
 		if (MD_only_iswg < 2 || !addr_str) {
 			ccow_lookup_release(biter);
@@ -330,6 +333,7 @@ build_isgw_service_table(ccow_t cl, struct isgw_service_entry** ptable) {
 				QUEUE_INIT(&ie->item);
 				strncpy(ie->addr, addr_str, sizeof(ie->addr));
 				ie->seg_uid = suid;
+				ie->mode = dfetch_mode;
 				QUEUE_INSERT_TAIL(&pe->isgw_addr_queue, &ie->item);
 				HASH_ADD_KEYPTR(hh,table,pe->bucketID,strlen(pe->bucketID),pe);
 			} else {
@@ -343,6 +347,7 @@ build_isgw_service_table(ccow_t cl, struct isgw_service_entry** ptable) {
 				QUEUE_INIT(&ie->item);
 				strncpy(ie->addr, addr_str, sizeof(ie->addr));
 				ie->seg_uid = suid;
+				ie->mode = dfetch_mode;
 				QUEUE_INSERT_TAIL(&pe->isgw_addr_queue, &ie->item);
 			}
 		}

--- a/src/ccow/src/libccow/ccow-dynamic-fetch.h
+++ b/src/ccow/src/libccow/ccow-dynamic-fetch.h
@@ -10,10 +10,23 @@
 
 #define ISGW_PROTO_VERSION 1
 
+enum eIsgwDynamicFetchType {
+	/*
+	 * The service can handle only MDonly objects
+	 */
+	eIsgwFTypeMDOnly = 0,
+	/*
+	 * The service can handle both MDonly objects
+	 * and an emergency chunk lookup
+	 */
+	eIsgwFTypeFull = 1
+};
+
 struct iswg_addr_item {
 	QUEUE item;
 	char  addr[64]; // IP of an ISGW server
 	uint64_t seg_uid;  // Segment UID
+	enum eIsgwDynamicFetchType mode; /* Dynamic fetch mode: MDonly or MDonly + emergency lookup */
 };
 
 typedef void (*ccow_isgw_proto_cb_t) (void *data, int status, void *rsp);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
Emergency lookup implementation. The ISGW's DFLocal address is used to fetch data/metadata chunk for cachable (MDonly) objects and for emergency chunk lookup. Emergency lookup feature allows us find a data/manifest chunk if it got lost on local setup, but could exist in any other segment connected to current one trough ISGW which serves tenant/bucket the object belongs to.
The ISGW service configuration must include an `X-ISGW-Emergency-Lookup=1` metadata entry along with the `X-ISGW-MDLocal=...` one.
There is a difference in how dynamic fetch is triggered for MDonly and emergency lookup. Lack of chunk for MDOnly object is detected by an unnamed get consensus, that is, when every VDEV in a row returned a negative reply for a chunk get proposal. A local object doesn't use get consensus technique at the beginning. It makes 3 attempts to fetch a chunk. If each attempt ends up with a get timeout, then the final get request is sent with consensus enabled. If it fails, then the dynamic fetch lookup will be triggered.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #299 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
