### PR TITLE
Common reptrans drivers bug in a dupsort iterator

### DIFF
--- a/src/ccow/src/libreptrans/rtkvs/reptrans-kvs.c
+++ b/src/ccow/src/libreptrans/rtkvs/reptrans-kvs.c
@@ -3660,11 +3660,26 @@ kvs_iterate_blobs_shard(struct repdev *dev, type_tag_t ttag,
 				op = MDB_GET_BOTH_RANGE;
 				data.mv_size = rtbuf(rbl, 1).len;
 				data.mv_data = rtbuf(rbl, 1).base;
+				/**
+				* Attempt to set position to a previous dupsort item.
+				* However, the mdb_cursor_get() can return a error if the entry was deleted
+				* So do a first lookup here and repeat it later with a closest key in a error case
+				*/
+				err = mdb_cursor_get(cursor, &key, pdata, op);
+				if (err) {
+					if (err == MDB_NOTFOUND)
+						op = MDB_SET_RANGE;
+					else {
+						log_error(lg, "Dev(%s) mdb_cursor_get() %d", dev->name, err);
+						err = -EIO;
+						break;
+					}
+				}
 			} else {
 				op = MDB_SET_RANGE;
 			}
 		}
-		while ((err = mdb_cursor_get(cursor, &key, pdata, op)) == 0) {
+		while ((op == MDB_GET_BOTH_RANGE) || ((err = mdb_cursor_get(cursor, &key, pdata, op)) == 0)) {
 			op = MDB_NEXT; // FIXME: why not MDB_NEXT_DUP in case of dup?
 
 			/* skip last key as it was processed in
@@ -3960,11 +3975,26 @@ kvs_iterate_blobs_nonstrict(struct repdev *dev, type_tag_t ttag,
 					op = MDB_GET_BOTH_RANGE;
 					data.mv_size = rtbuf(rbl, 1).len;
 					data.mv_data = rtbuf(rbl, 1).base;
+					/**
+					* Attempt to set position to a previous dupsort item.
+					* However, the mdb_cursor_get() can return a error if the entry was deleted
+					* So do a first lookup here and repeat it later with a closest key in a error case
+					*/
+					err = mdb_cursor_get(cursor, &key, pdata, op);
+					if (err) {
+						if (err == MDB_NOTFOUND)
+							op = MDB_SET_RANGE;
+						else {
+							log_error(lg, "Dev(%s) mdb_cursor_get() %d", dev->name, err);
+							err = -EIO;
+							break;
+						}
+					}
 				} else {
 					op = MDB_SET_RANGE;
 				}
 			}
-			while ((err = mdb_cursor_get(cursor, &key, pdata, op)) == 0) {
+			while ((op == MDB_GET_BOTH_RANGE) || ((err = mdb_cursor_get(cursor, &key, pdata, op)) == 0)) {
 				op = MDB_NEXT; // FIXME: why not MDB_NEXT_DUP in case of dup?
 
 				/* skip last key as it was processed in

--- a/src/ccow/src/libreptrans/rtrd/reptrans-rd.c
+++ b/src/ccow/src/libreptrans/rtrd/reptrans-rd.c
@@ -8012,11 +8012,26 @@ rd_iterate_blobs_shard(struct repdev *dev, type_tag_t ttag,
 				op = MDB_GET_BOTH_RANGE;
 				data.mv_size = rtbuf(rbl, 1).len;
 				data.mv_data = rtbuf(rbl, 1).base;
+				/**
+				* Attempt to set position to a previous dupsort item.
+				* However, the mdb_cursor_get() can return a error if the entry was deleted
+				* So do a first lookup here and repeat it later with a closest key in a error case
+				*/
+				err = mdb_cursor_get(cursor, &key, pdata, op);
+				if (err) {
+					if (err == MDB_NOTFOUND)
+						op = MDB_SET_RANGE;
+					else {
+						log_error(lg, "Dev(%s) mdb_cursor_get() %d", dev->name, err);
+						err = -EIO;
+						break;
+					}
+				}
 			} else {
 				op = MDB_SET_RANGE;
 			}
 		}
-		while ((err = mdb_cursor_get(cursor, &key, pdata, op)) == 0) {
+		while ((op == MDB_GET_BOTH_RANGE) || ((err = mdb_cursor_get(cursor, &key, pdata, op)) == 0)) {
 			op = MDB_NEXT; // FIXME: why not MDB_NEXT_DUP in case of dup?
 
 			/* skip last key as it was processed in
@@ -8589,11 +8604,20 @@ _next_shard:
 					op = MDB_GET_BOTH_RANGE;
 					data.mv_size = rtbuf(rbl, 1).len;
 					data.mv_data = rtbuf(rbl, 1).base;
+					err = mdb_cursor_get(cursor, &key, pdata, op);
+					if (err) {
+						if (err == MDB_NOTFOUND)
+							op = MDB_SET_RANGE;
+					} else {
+						log_error(lg, "Dev(%s) mdb_cursor_get() %d", dev->name, err);
+						err = -EIO;
+						break;
+					}
 				} else {
 					op = MDB_SET_RANGE;
 				}
 			}
-			while ((err = mdb_cursor_get(cursor, &key, pdata, op)) == 0) {
+			while ((op == MDB_GET_BOTH_RANGE) || ((err = mdb_cursor_get(cursor, &key, pdata, op)) == 0)) {
 				op = MDB_NEXT; // FIXME: why not MDB_NEXT_DUP in case of dup?
 
 				/* skip last key as it was processed in


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
Fixed a bug in dupsort iterator

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #339

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
