### PR TITLE
Issue 344

### DIFF
--- a/src/ccow/src/libreplicast/replicast.h
+++ b/src/ccow/src/libreplicast/replicast.h
@@ -507,7 +507,7 @@ struct repmsg_ngrequest_purge {
 	uint64_t hi_version;
 	uint64_t low_version;
 	uint64_t version_uvid_timestamp;
-	uint8_t is_trlog_obj;
+	uint8_t flags;
 	uint8_t hash_type;
 	int32_t status;
 };

--- a/src/ccow/src/libreptrans/named-put.c
+++ b/src/ccow/src/libreptrans/named-put.c
@@ -1008,10 +1008,8 @@ _ack_exit:
 		!(req->md.object_deleted == RT_DELETED_EXPUNGED_VERSION) &&
 	    (req->md.number_of_versions > 0) &&
 	    (ron->generation > req->md.number_of_versions)) {
-		int is_trlog_obj = (req->md.tid_size >= strlen(TRLOG_TID_PREFIX) &&
-		    strncmp(req->md.tid, TRLOG_TID_PREFIX, strlen(TRLOG_TID_PREFIX)) == 0);
 		err = ngrequest_purge(dev, req->hash_type, &req->md.nhid,
-		    ron->generation - req->md.number_of_versions, 0, 0, is_trlog_obj);
+		    ron->generation - req->md.number_of_versions, 0, 0, 0);
 		if (err) {
 			/* Not fatal, BG verification will eventually fix this */
 			log_warn(lg, "Dev(%s): cannot purge request, err %d",

--- a/src/ccow/src/libreptrans/ngrequest-purge.c
+++ b/src/ccow/src/libreptrans/ngrequest-purge.c
@@ -233,7 +233,7 @@ reptrans_dev_async_call__purge(struct repdev_call *c)
 	uint64_t hi_version = (uint64_t)c->args[3];
 	uint64_t low_version = (uint64_t)c->args[4];
 	uint64_t version_uvid_timestamp = (uint64_t)c->args[5];
-	uint8_t is_trlog_obj = (uint8_t)((uint64_t)c->args[6] & 0xff);
+	uint8_t flags = (uint8_t)((uint64_t)c->args[6] & 0xff);
 
 	assert(dev);
 	assert(nhid);
@@ -252,7 +252,7 @@ reptrans_dev_async_call__purge(struct repdev_call *c)
 	r->hi_version = hi_version;
 	r->low_version = low_version;
 	r->version_uvid_timestamp = version_uvid_timestamp;
-	r->is_trlog_obj = is_trlog_obj;
+	r->is_trlog_obj = flags;
 	r->hash_type = hash_type;
 
 	log_debug(lg,
@@ -299,7 +299,7 @@ reptrans_dev_async_call__purge(struct repdev_call *c)
 int
 ngrequest_purge(struct repdev *dev, uint8_t hash_type, const uint512_t *nhid,
 	uint64_t hi_version, uint64_t low_version, uint64_t version_uvid_timestamp,
-	uint8_t is_trlog_obj)
+	uint8_t flags)
 {
 	int err;
 	if (unlikely((lg->level <= LOG_LEVEL_TRACE))) {
@@ -326,7 +326,7 @@ ngrequest_purge(struct repdev *dev, uint8_t hash_type, const uint512_t *nhid,
 	call->args[3] = (void *)hi_version;
 	call->args[4] = (void *)low_version;
 	call->args[5] = (void *)version_uvid_timestamp;
-	call->args[6] = (void *)(uint64_t)is_trlog_obj;
+	call->args[6] = (void *)(uint64_t)flags;
 
 	QUEUE_INIT(&call->item);
 	repdev_status_t status = reptrans_dev_get_status(dev);

--- a/src/ccow/src/libreptrans/reptrans.c
+++ b/src/ccow/src/libreptrans/reptrans.c
@@ -4318,7 +4318,7 @@ reptrans_validate_verified_br(struct repdev *dev, const uint512_t* chid,
 _replicate_vbrs:;
 
 	type_tag_t chunk_ttag = reptrans_backref_attr2ttag(vbr->attr);
-	if (chunk_ttag == TT_INVALID) {
+	if (!dev->bg_config->vbr_replication || chunk_ttag == TT_INVALID) {
 		/*
 		 * Previous VBR version (prior nedge 2.2) didn't keep chunk ttag
 		 * in VBR and such VBRs cannot be replicated
@@ -10643,6 +10643,13 @@ reptrans_parse_bg_jobs_config(const json_value* obj, struct repdev_bg_config* cf
 				return -EINVAL;
 			}
 			cfg->elru_hits_count = v->u.integer;
+		}  else if (strncmp(namekey, "vbr_replication", 15) == 0) {
+			if (v->type != json_integer || v->u.integer < 0) {
+				log_error(lg, "Syntax error: a VBR replication feature enable "
+					"flag has to be 0 or 1");
+				return -EINVAL;
+			}
+			cfg->vbr_replication = v->u.integer;
 		}
 	}
 	return 0;

--- a/src/ccow/src/libreptrans/reptrans.c
+++ b/src/ccow/src/libreptrans/reptrans.c
@@ -9309,7 +9309,7 @@ _exit:
 int
 reptrans_purge_versions(struct repdev *dev, const uint512_t *nhid,
 	uint64_t hi_version, uint64_t low_version, uint64_t version_uvid_timestamp,
-	crypto_hash_t hash_type, int trlog_object)
+	crypto_hash_t hash_type)
 {
 	/*
 	 * 1. Read all the object versions, add version_uvid_timestamp to query if required

--- a/src/ccow/src/libreptrans/reptrans.h
+++ b/src/ccow/src/libreptrans/reptrans.h
@@ -179,6 +179,7 @@ struct mcjoin_queue_entry {
 #define DEV_ELRU_HIT_COUNTER			2
 #define DEV_ELRU_TOUCH_RATIO			1 /* 0.1% */
 #define DEV_VBR_REPLICATION_ENA			1
+#define DEV_GC_BATCH_DEFER_TIMEOUT		(30UL*1000UL*1000UL)
 
 /*
  * control flags for reptrans_flush()

--- a/src/ccow/src/libreptrans/reptrans.h
+++ b/src/ccow/src/libreptrans/reptrans.h
@@ -178,6 +178,7 @@ struct mcjoin_queue_entry {
 #define DEV_MDONLY_TOUCH_TABLE_SIZE_EMBEDDED	(2UL*1024UL*1024UL)
 #define DEV_ELRU_HIT_COUNTER			2
 #define DEV_ELRU_TOUCH_RATIO			1 /* 0.1% */
+#define DEV_VBR_REPLICATION_ENA			1
 
 /*
  * control flags for reptrans_flush()
@@ -275,6 +276,7 @@ struct repdev_bg_config {
 	uint32_t tp_hi_resiliency;
 	uint32_t elru_touch_ratio; /* %*10 of speculative_backref_timeout_min */
 	uint32_t elru_hits_count; /* Number of chunk hits prior first touch */
+	uint32_t vbr_replication; /* Enable or disable a VBR replication feature */
 };
 
 #define REPDEV_CAPACITY_LIMIT			0.87

--- a/src/ccow/src/libreptrans/reptrans.h
+++ b/src/ccow/src/libreptrans/reptrans.h
@@ -1012,8 +1012,7 @@ int reptrans_put_version(struct repdev *dev, struct vmmetadata *md,
 
 int reptrans_purge_versions(struct repdev *dev, const uint512_t *nhid,
 	uint64_t from_version, uint64_t to_version,
-	uint64_t version_uvid_timestamp, crypto_hash_t hash_type,
-	int trlog_object);
+	uint64_t version_uvid_timestamp, crypto_hash_t hash_type);
 
 /*
  * @internal
@@ -1182,6 +1181,9 @@ int
 ngcount_generations(struct repdev *dev, const uint512_t *nhid,
     uint64_t *generation_max);
 
+
+#define NGREQUEST_PURGE_FLAG_DROP_STABLE_VERSION (1<<1) /* Drop a cached stable version */
+
 /*
  * Tell all devices in negotiation group to purge old versions
  *
@@ -1190,7 +1192,7 @@ ngcount_generations(struct repdev *dev, const uint512_t *nhid,
 int
 ngrequest_purge(struct repdev *dev, uint8_t hash_type, const uint512_t *nhid,
 	uint64_t from_version, uint64_t to_version, uint64_t version_uvid_timestamp,
-	uint8_t is_trlog_obj);
+	uint8_t flags);
 
 /*
  * Remove a manifest along with its parity manifest

--- a/src/ccow/src/libreptrans/reptrans_bg_sched.c
+++ b/src/ccow/src/libreptrans/reptrans_bg_sched.c
@@ -187,6 +187,7 @@ bg_set_default_config (struct repdev_bg_config* cfg) {
 	cfg->tp_hi_resiliency =DEV_TP_HI_WEIGHT;
 	cfg->elru_hits_count = DEV_ELRU_HIT_COUNTER;
 	cfg->elru_touch_ratio = DEV_ELRU_TOUCH_RATIO;
+	cfg->vbr_replication = DEV_VBR_REPLICATION_ENA;
 }
 
 #define FOREACH_BG(sched, job) \

--- a/src/ccow/src/libreptrans/verify.c
+++ b/src/ccow/src/libreptrans/verify.c
@@ -920,6 +920,8 @@ reptrans_verify_queue__callback(struct repdev *dev, type_tag_t ttag,
 			/* Remove "stable version" entry if a version has passed
 			 * the quarantine */
 			reptrans_stable_version_delete(dev, &vbreq->nhid);
+			err = ngrequest_purge(dev, HASH_TYPE_DEFAULT, &vbreq->nhid,
+				0,0,0, NGREQUEST_PURGE_FLAG_DROP_STABLE_VERSION);
 			log_info(lg, "Dev(%s) object NHID %lX "
 				" gen %lu has passed quarantine", dev->name,
 				vbreq->vbr.name_hash_id.u.u.u, vbreq->generation);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
1. The coordinated drop of the latest stable version's cache entry. The ngrequest-purge is used for this purpose with an additional flag in a request body.
2. A garbage collector's deferred work can be triggered by a timeout. It improves a version top-down delete performance.
3. Experimental. VBR replication feature can be disabled in ccowd.json by setting `"vbr_replication": 0`

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #344

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
