### PR TITLE
SOP based transaction log

### DIFF
--- a/src/ccow/include/ccow.h
+++ b/src/ccow/include/ccow.h
@@ -1590,9 +1590,13 @@ ccow_shard_context_set_overwrite(ccow_shard_context_t shard_context, int overwri
 
 /**
  * Set eventual flag for shard_context.
+ *
+ * @param shard_context - shard context pointer
+ * @param eventual - eventual flag: 1 on, 0 off
+ * @param eventual_cache - keep eventual cache flag: 1 on, 0 off
  */
 int
-ccow_shard_context_set_eventual(ccow_shard_context_t shard_context, int eventual);
+ccow_shard_context_set_eventual(ccow_shard_context_t shard_context, int eventual, int eventual_cache);
 
 /**
  * Set inline data flag for shard_context.
@@ -1636,13 +1640,24 @@ ccow_sharded_attributes_create(ccow_t tctx, const char *bid, size_t bid_size,
  * @param tctx the tenant cluster context
  * @param bid the NULL terminated string of name id of the bucket
  * @param bid_size bucket id size
- * @param shard_name the NULL terminated string of shard name id
- * @param shard_name_size shard name size
- * @param shard_count shard count should be 2^n
+ * @param shard_context sharded list context
  * @returns 0 on success, negative error code on failure
  */
 int
 ccow_sharded_list_destroy(ccow_t tctx, const char *bid, size_t bid_size,
+		ccow_shard_context_t shard_context);
+
+/**
+ * Flush sharded list
+ *
+ * @param tctx the tenant cluster context
+ * @param bid the NULL terminated string of name id of the bucket
+ * @param bid_size bucket id size
+ * @param shard_context sharded list context
+ * @returns 0 on success, negative error code on failure
+ */
+int
+ccow_sharded_list_flush(ccow_t tctx, const char *bid, size_t bid_size,
 		ccow_shard_context_t shard_context);
 
 /**

--- a/src/ccow/src/libccow/ccow-impl.h
+++ b/src/ccow/src/libccow/ccow-impl.h
@@ -700,6 +700,7 @@ struct ccow_shard_context {
 	int encryption;
 	int overwrite;
 	int eventual;
+	int eventual_cache;
 	uint16_t inline_data_flag;
 };
 

--- a/src/ccow/src/libccowfsio/fsio_dir.c
+++ b/src/ccow/src/libccowfsio/fsio_dir.c
@@ -526,7 +526,7 @@ ccow_fsio_dir_context_create(ccowfs_inode * inode)
 	 */
 	if (ccow_mh_immdir == 0) {
 		log_trace(fsio_lg, "%s context set eventual", __func__);
-		ccow_shard_context_set_eventual(inode->dir_list_context, 1);
+		ccow_shard_context_set_eventual(inode->dir_list_context, 1, 1);
 	}
 
 out:

--- a/src/ccow/src/libreplicast/replicast.h
+++ b/src/ccow/src/libreplicast/replicast.h
@@ -68,6 +68,7 @@ extern "C" {
 /* reserved system values */
 #define RT_SYSVAL_TENANT_ADMIN			"root"
 #define RT_SYSVAL_TENANT_SVCS			"svcs"
+#define RT_SYSVAL_PSEVDO_BUCKET_TRLOG	"TRLOG"
 #define RT_SYSVAL_REPLICATION_COUNT		3
 #define RT_SYSVAL_SYNC_PUT			0
 #define RT_SYSVAL_SYNC_PUT_NAMED		3
@@ -409,6 +410,8 @@ struct replicast_datagram_hdr {
 #define REPLICAST_UNICAST_UDP_MCPROXY	3
 
 #define REPLICAST_TCP_KEEPALIVE		10 /* in secs */
+
+#define TRLOG_SHARD_COUNT	8
 
 struct replicast_rendezvous_proposal {
 	uint64_t start_time;		/* time when the client can start */

--- a/src/ccow/src/libreptrans/reptrans.h
+++ b/src/ccow/src/libreptrans/reptrans.h
@@ -208,6 +208,7 @@ struct mcjoin_queue_entry {
 #define COMPOUND_MAX_CHUNKS	5*1024
 #define COMPOUND_SIZE_MAX	(REPLICAST_CHUNK_SIZE_MAX-COMPOUND_HDR_SIZE) /* TODO: figure out why 8Mb+65536 bytes doesn't work */
 
+
 struct repdev_bg_config {
 	int64_t backref_verify_timer_ms;
 	int64_t backref_verify_start_ms;
@@ -510,7 +511,6 @@ struct repdev {
 	int joined_rows[FH_MAX_JOINED_ROWS];
 	QUEUE mcjoin_queue;
 	uint32_t mcjoin_size;
-	int trlog_bucket_ready;
 
 	/* Hashtable for locks */
 	hashtable_t *lock_tbl;
@@ -1325,10 +1325,10 @@ typedef struct trlog_work {
 	struct ccow_daemon *ccowd;
 	uint64_t batch_seq_prev_ts;
 	uint64_t batch_seq_ts;
-	ccow_completion_t c;
 	int index;
 	int stale;
 	char *oid;
+	ccow_shard_context_t trlog_shard_context;
 	uint512_t* processed_vmchids;
 	uint512_t* stale_vmchids;
 } trlog_work_t;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description

To avoid merge-sort of per-device time series of our distributed transaction log, we will instead pre-sort inserts into transaction log interval NoSQL table.
This change improves transaction log performance for heavy version modifications by at least 200%.

User-visible change is that now with this change when we insert 10M+ objects into the S3 bucket for NFS directory, the transaction log will not lag behind as it used to be and should be able to keep up.

#### Special notes for the reviewer(s)

This change requires a cluster restart.

#### Which issue this PR fixes

fixes #269 

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
