### PR TITLE
Issue 222

### DIFF
--- a/src/ccow/include/ccow.h
+++ b/src/ccow/include/ccow.h
@@ -1303,7 +1303,7 @@ typedef enum {
 } ondemand_policy_t;
 
 /**
- * Asynchronously trigger a cacheable object's policy change
+ * Asynchronously trigger a cacheable object's policy change (latest object version)
  *
  * @param bid bucket name id of the bucket
  * @param bid_size of bucket name ID
@@ -1317,8 +1317,6 @@ int
 ccow_ondemand_policy_change_request(const char *bid, size_t bid_size, const char *oid,
 	size_t oid_size, uint64_t generation, ondemand_policy_t pol,
 	ccow_completion_t comp);
-
-
 
 /**
  * Change a cacheable (mdonly) object's policy. Blocking call.
@@ -2062,8 +2060,6 @@ struct ccow_copy_opts {
 	size_t oid_size;
 	uint64_t *genid;  /* Source generation id (optional) */
 	uint64_t version_uvid_timestamp; /* Source version timestamp (optional) */
-	char *version_vm_content_hash_id; /* Source vm hash id (optional) */
-	char *vm_chid;		/* pointer to 512bit VM CHID */
 	uint8_t md_override; /* Don't inherit source's default metadata */
 };
 

--- a/src/ccow/src/libccow/ccow.c
+++ b/src/ccow/src/libccow/ccow.c
@@ -2365,6 +2365,12 @@ ccow_create_completion(ccow_t cluster, void *cb_arg,
 	(_ptr_to)->object_delete_after = (_ptr_from)->object_delete_after; \
 	(_ptr_to)->inline_data_flags = (_ptr_from)->inline_data_flags;
 
+#define PROP_INH_CLONE(_ptr_from, _ptr_to) \
+	(_ptr_to)->ec_enabled = (_ptr_from)->ec_enabled; \
+	(_ptr_to)->ec_data_mode = (_ptr_from)->ec_data_mode; \
+	(_ptr_to)->ec_trg_policy = (_ptr_from)->ec_trg_policy;
+
+
 int
 ccow_copy_inheritable_md(ccow_completion_t comp_in, ccow_completion_t comp_out)
 {
@@ -2423,6 +2429,13 @@ ccow_copy_inheritable_comp_to_md(struct ccow_completion *comp_from,
     struct vmmetadata *md_to)
 {
 	PROP_INH(comp_from, md_to);
+}
+
+void
+ccow_copy_inheritable_comp_to_md_clone(struct ccow_completion *comp_from,
+    struct vmmetadata *md_to)
+{
+	PROP_INH_CLONE(comp_from, md_to);
 }
 
 void

--- a/src/ccow/src/libccow/named-get.c
+++ b/src/ccow/src/libccow/named-get.c
@@ -629,18 +629,19 @@ namedget_process_payload(struct state *st)
 	* then just allocate data structure. Its content will be filled upon
 	* payload fetch request. Do not try dynamic fetch for buckets.
 	*/
+	const char *bid = op->comp->isgw_bid ? op->comp->isgw_bid : op->bid;
 	if (strcmp(op->tid, RT_SYSVAL_TENANT_ADMIN) &&
 		strcmp(op->tid, RT_SYSVAL_TENANT_SVCS) &&
 		op->oid_size > 1 &&
 		!op->isgw_dfetch &&
-		ccow_bucket_isgw_lookup(op->cid, op->tid, op->bid, NULL) == 0)
+		ccow_bucket_isgw_lookup(op->cid, op->tid, bid, NULL) == 0)
 		op->isgw_dfetch = 1;
 	/*
 	 * Preset some of completion defaults for comp-hash while
 	 * doing stream or normal (below) PUTs
 	 */
 	if (op->copy_opts && op->copy_opts->md_override) {
-		ccow_copy_inheritable_comp_to_md(op->comp, &op->metadata);
+		ccow_copy_inheritable_comp_to_md_clone(op->comp, &op->metadata);
 	} else
 		ccow_copy_inheritable_md_to_comp(&op->metadata, op->comp);
 	if (rb != comp->ver_rb)

--- a/src/ccow/src/libccow/snapview.c
+++ b/src/ccow/src/libccow/snapview.c
@@ -23,8 +23,9 @@
  */
 #include "ccowutil.h"
 #include "ccow-impl.h"
+#include "ccow-dynamic-fetch.h"
 
-
+#define SNAPVIEW_OBJECT_SUFFIX ".snapview"
 /*
  * Handle for snapview objects.
  */
@@ -148,6 +149,8 @@ clone_unnamed_get_cb(struct getcommon_client_req *r)
 	c->ver_name->tid_size = md->tid_size;
 	c->ver_name->bid_size = md->bid_size;
 	c->ver_name->oid_size = md->oid_size;
+	if (*md->oid == 0)
+		ccow_copy_inheritable_md_to_comp(md, c);
 
 	c->ver_rb = rtbuf_clone_bufs(r->rb);
 	if (!c->ver_rb) {
@@ -159,6 +162,65 @@ clone_unnamed_get_cb(struct getcommon_client_req *r)
 	return;
 }
 
+static int
+ccow_snapshot_lookup_internal(ccow_t tctx, ccow_snapview_t sv_hdl,
+    const char *pattern, size_t p_size, size_t count, ccow_lookup_t *iter,
+    ccow_completion_t c, int* idx) {
+	char buf[CCOW_CLUSTER_CHUNK_SIZE];
+	struct iovec iov = { .iov_base = buf };
+	memcpy(iov.iov_base, pattern, p_size);
+	iov.iov_len = p_size;
+	int err = ccow_get_list(sv_hdl->sv_bid, sv_hdl->sv_bid_size, sv_hdl->sv_oid,
+	    sv_hdl->sv_oid_size, c, &iov, 1, count, iter);
+	if (err) {
+		log_error(lg, "ccow_snapshot_lookup_async: ccow_get_list error %d", err);
+		return err;
+	}
+
+	err = ccow_wait(c, *idx);
+	(*idx)++;
+	if (err) {
+		if (iter && *iter) {
+			ccow_lookup_release(*iter);
+			*iter = NULL;
+		}
+		log_error(lg, "Error while reading snapview object %d", err);
+	}
+	return err;
+}
+
+/*
+ * SCOPE: Public
+ *
+ * List the stored contents of a snapview.
+ * @param sv_hdl snapview handle
+ * Return zero on success, error otherwise.
+ */
+int
+ccow_snapshot_lookup(ccow_t tctx, ccow_snapview_t sv_hdl,
+    const char *pattern, size_t p_size, size_t count, ccow_lookup_t *iter)
+{
+	assert(sv_hdl);
+
+	int err;
+	struct ccow *tc = tctx;
+	ccow_completion_t c;
+
+	if (pattern && p_size == 0)
+		return -EINVAL;
+
+	err = ccow_create_completion(tc, NULL, NULL, 1, &c);
+	if (err)
+		return err;
+	int idx = 0;
+	err = ccow_snapshot_lookup_internal(tctx, sv_hdl, pattern, p_size, count,
+		iter, c, &idx);
+
+	ccow_release(c);
+	return err;
+}
+
+
 /*
  * Grab a CHID from the BT-Name Index, return NULL on error;
  *
@@ -166,14 +228,15 @@ clone_unnamed_get_cb(struct getcommon_client_req *r)
  */
 static int
 ccow_snapview_get_chid_by_name(ccow_t tctx, ccow_snapview_t sv_hdl,
-    const char *ss_name, size_t ss_name_size)
+    const char *ss_name, size_t ss_name_size, ccow_completion_t c, int* idx)
 {
 	int err;
 	struct ccow *tc = (struct ccow *)tctx;
 	struct ccow_snapview *sv = (struct ccow_snapview *)sv_hdl;
 
 	ccow_lookup_t iter;
-	err = ccow_snapshot_lookup(tc, sv, ss_name, ss_name_size, 1, &iter);
+	err = ccow_snapshot_lookup_internal(tc, sv, ss_name, ss_name_size, 1, &iter,
+		c, idx);
 	if (err) {
 		if (iter)
 			ccow_lookup_release(iter);
@@ -206,6 +269,96 @@ ccow_snapview_get_chid_by_name(ccow_t tctx, ccow_snapview_t sv_hdl,
 	return -ENOENT;
 }
 
+/**
+ * An object/tenant referenced by an mdonly snapshot usually doesn't have a local VM
+ * It needs to be fetched from remote. The used has to provide the
+ * dyn_fetch, tid/bid and optional oid parameters.
+ */
+static int
+ccow_clone_vm_prefetch(ccow_t tc, uint512_t* vmchid, uint512_t* nhid,
+	const char* tid, size_t tid_size,
+	const char* bid, size_t bid_size,
+	const char* oid, size_t oid_size,
+	int dyn_fetch,
+	ccow_completion_t c) {
+
+	assert(vmchid);
+	assert(nhid);
+	assert(tc);
+
+	c->vm_name_hash_id = *nhid;
+	struct ccow_op *ug_op;
+	struct ccow_io *get_io;
+	/*
+	 * Fetch metadata of a source object/bucket
+	 */
+	int err = ccow_operation_create(c, CCOW_CLONE, &ug_op);
+	if (err) {
+		log_error(lg, "Operation create error %d", err);
+		return err;
+	}
+
+	err = ccow_unnamedget_create(c, clone_unnamed_get_cb, ug_op, &get_io,
+	    NULL);
+	if (err) {
+		ccow_operation_destroy(ug_op, 1);
+		log_error(lg, "error returned by ccow_unnamedget_create: %d",err);
+		return err;
+	}
+	struct iovec iov;
+	iov.iov_base = "";
+	iov.iov_len = 1;
+
+	ug_op->iov_in = &iov;
+	ug_op->iovcnt_in = 1;
+	ug_op->offset = 0;
+
+	ug_op->chunks = rtbuf_init_mapped((uv_buf_t *)&iov, 1);
+	get_io->attributes |= RD_ATTR_VERSION_MANIFEST;
+	struct getcommon_client_req *req = CCOW_IO_REQ(get_io);
+	if (tid && tid_size > 1 && *tid != 0 && bid && bid_size > 1 && *bid != 0) {
+		ug_op->cid = je_memdup(tc->cid, tc->cid_size);
+		if (!ug_op->cid)
+			return -ENOMEM;
+
+		ug_op->tid = je_memdup(tid, tid_size);
+		if (!ug_op->tid)
+			return -ENOMEM;
+
+		ug_op->bid = je_memdup(bid, bid_size);
+		if (!ug_op->bid)
+			return -ENOMEM;
+
+		ug_op->oid = je_memdup(oid, oid_size);
+		if (!ug_op->oid)
+			return -ENOMEM;
+
+		ug_op->cid_size = tc->cid_size;
+		ug_op->tid_size = tid_size;
+		ug_op->bid_size = bid_size;
+		ug_op->oid_size = oid_size;
+
+		if (dyn_fetch) {
+			get_io->attributes |= RD_ATTR_GET_CONSENSUS;
+			ug_op->isgw_dfetch = 1;
+			RT_ONDEMAND_SET(ug_op->metadata.inline_data_flags, ondemandPolicyUnpin);
+			/*
+			 * Prepare refentry for ISGW
+			 * Set entry type to inline just for ISGW to distinguish CM/CP/VM
+			 */
+			req->ref.content_hash_id = *vmchid;
+			req->ref.name_hash_id = *nhid;
+			RT_REF_TYPE_SET(&req->ref, RT_REF_TYPE_INLINE_VERSION);
+			RT_REF_HASH_TYPE_SET(&req->ref, HASH_TYPE_DEFAULT);
+		}
+	}
+
+	req->ng_chid = *nhid;
+	req->chid = *vmchid;
+	req->offset = 0;
+	return ccow_start_io(get_io);
+}
+
 /*
  * Clone an object from a snapshot handle.
  *
@@ -221,69 +374,100 @@ ccow_clone_snapview_object(ccow_t tctx, ccow_snapview_t sv_hdl,
 	struct ccow *tc = (struct ccow *)tctx;
 	struct ccow_snapview *sv = (struct ccow_snapview *)sv_hdl;
 
+	ccow_completion_t c;
+	int io_idx = 0;
+	err = ccow_create_completion(tc, NULL, NULL, 4, &c);
+	if (err)
+		return err;
+
 	/*
 	 * Phase 1:  unnamed_get on the CHID of the sv_hdl->vm_chid, this will
 	 * return a req->payload which is the actual version manifest.
 	 */
 
 	err = ccow_snapview_get_chid_by_name(tctx, sv_hdl, ss_name,
-	    ss_name_size);
-	if (err)
-		return err;
-
-	struct ccow_op *ug_op;
-	struct ccow_io *get_io;
-	ccow_completion_t c;
-	err = ccow_create_completion(tc, NULL, NULL, 2, &c);
-	if (err)
-		return err;
-
-	c->vm_name_hash_id = sv->sv_vm_nhid;
-
-	err = ccow_operation_create(c, CCOW_CLONE, &ug_op);
+	    ss_name_size, c, &io_idx);
 	if (err) {
-		ccow_drop(c);
+		log_error(lg, "clone: couldn't find a reference VM of the snapshot %s", ss_name);
 		return err;
 	}
-
-	err = ccow_unnamedget_create(c, clone_unnamed_get_cb, ug_op, &get_io,
-	    NULL);
-	if (err) {
-		ccow_operation_destroy(ug_op, 1);
-		ccow_drop(c);
-		log_error(lg, "error returned by ccow_unnamedget_create: %d",
-		    err);
-		return err;
-	}
-	ug_op->iov_in = NULL;
-	ug_op->iovcnt_in = 0;
-	ug_op->offset = 0;
-
-	get_io->attributes |= RD_ATTR_VERSION_MANIFEST;
-
-	struct getcommon_client_req *req = CCOW_IO_REQ(get_io);
-
-	/* Calculated above by ccow_snapview_get_chid_by_name */
-	req->ng_chid = sv->sv_vm_nhid;
-	req->chid = sv->sv_vm_chid;
-	req->offset = 0;
-
-	/*
-	 * Phase 2:  post-process the unnamedget payload in the cb and
-	 * use this to construct the VM/MD/CM/RL to be passed to the copy
-	 * operation.
+	/**
+	 *    NOTE: An mdonly snapshot can be cloned only if a canonical
+	 *    snapshot name is used because an ISGW server will be chosen by a
+	 *    bucket name.
 	 */
+	char scid[PATH_MAX] = {0};
+	char stid[PATH_MAX] = {0};
+	char sbid[PATH_MAX] = {0};
+	char soid[PATH_MAX] = {0};
+	int canonical_name = 0;
 
-	err = ccow_start_io(get_io);
+	char *tid_src = stid;
+	char *bid_src = sbid;
+	char *oid_src = soid;
+	size_t tid_src_size = 1;
+	size_t bid_src_size = 1;
+	size_t oid_src_size = 1;
+
+
+	err = sscanf(ss_name, "%2047[^/]/%2047[^/]/%2047[^/]/%2047[^@]",
+		scid, stid, sbid, soid);
+	if (err == 4) {
+		tid_src_size = strlen(stid) + 1;
+		bid_src_size = strlen(sbid) + 1;
+		oid_src_size = strlen(soid) + 1;
+		canonical_name = 1;
+	} else if (err == 3) {
+		/* possibly a bucket snapshot */
+		err = sscanf(ss_name, "%2047[^/]/%2047[^/]/%2047[^@]",
+			scid, stid, sbid);
+		if (err == 3) {
+			canonical_name = 1;
+			tid_src_size = strlen(stid) + 1;
+			bid_src_size = strlen(sbid) + 1;
+		}
+	}
+
+	/**
+	 * The completion is keeping metadata of the snapview object.
+	 */
+	int mdonly = RT_ONDEMAND_GET(c->inline_data_flags);
+	/**
+	 * Override source bucket ID to route dynamic fetch requests to a proper segment
+	 */
+	if (mdonly)
+		c->isgw_bid = sv_hdl->sv_bid;
+	else
+		c->isgw_bid = NULL;
+	/**
+	 * Phase 2: Try to fetch a VM for the object referenced by the snapshot.
+	 * It might be needed for mdonly snapshot
+	 */
+	err = ccow_clone_vm_prefetch(tc, &sv->sv_vm_chid, &sv->sv_vm_nhid,
+		tid_src, tid_src_size, bid_src, bid_src_size,
+		oid_src, oid_src_size, mdonly, c);
 	if (err) {
-		ccow_operation_destroy(ug_op, 1);
+		log_error(lg, "A snapshot's object reference VM %016lX prefetch start error: %d",
+			sv->sv_vm_chid.u.u.u, err);
 		ccow_drop(c);
 		return err;
 	}
-	err = ccow_wait(c, 0);
+	err = ccow_wait(c, io_idx++);
 	if (err) {
+		log_error(lg, "A snapshot's object reference VM %016lX prefetch wait error: %d",
+			sv->sv_vm_chid.u.u.u, err);
 		ccow_drop(c);
 		return err;
+
+	}
+	/* gather tid/bid/oid/src from the payload*/
+	if (!canonical_name) {
+		tid_src = c->ver_name->tid;
+		bid_src = c->ver_name->bid;
+		oid_src = c->ver_name->oid;
+		tid_src_size = c->ver_name->tid_size;
+		bid_src_size = c->ver_name->bid_size;
+		oid_src_size = c->ver_name->oid_size;
 	}
 
 	struct ccow_copy_opts copy_opts;
@@ -295,19 +479,17 @@ ccow_clone_snapview_object(ccow_t tctx, ccow_snapview_t sv_hdl,
 	copy_opts.oid_size = oid_dst_size;
 	copy_opts.genid = NULL;
 	copy_opts.version_uvid_timestamp = 0;
-	copy_opts.version_vm_content_hash_id = NULL;
+	copy_opts.md_override = 0;
 
-	/* gather tid/bid/oid/src from the payload*/
-	char *tid_src = c->ver_name->tid;
-	char *bid_src = c->ver_name->bid;
-	char *oid_src = c->ver_name->oid;
-	size_t tid_src_size = c->ver_name->tid_size;
-	size_t bid_src_size = c->ver_name->bid_size;
-	size_t oid_src_size = c->ver_name->oid_size;
 
 	/* In case of Rollback we've passed NULL/NULL/NULL, so use the same
 	 * tid/bid/oid as the src which is completed by the ccow_wait on UG. */
 	if (!tid_dst && !bid_dst && !oid_dst) {
+		if (*oid_src == 0) {
+			ccow_release(c);
+			log_error(lg, "bucket rollback is NOT supported. Use a bucket clone instead");
+			return -ENOTSUP;
+		}
 		copy_opts.tid = tid_src;
 		copy_opts.tid_size = tid_src_size;
 		copy_opts.bid = bid_src;
@@ -315,22 +497,186 @@ ccow_clone_snapview_object(ccow_t tctx, ccow_snapview_t sv_hdl,
 		copy_opts.oid = oid_src;
 		copy_opts.oid_size = oid_src_size;
 	}
-	/* Issue Clone! */
-	err = ccow_clone(c, tid_src, tid_src_size, bid_src, bid_src_size,
-	    oid_src, oid_src_size, &copy_opts);
-	if (err) {
+	if (*oid_src != 0) {
+		/* Don't clone snapview objects because the will loose a segment context */
+		char* p = strstr(oid_src, SNAPVIEW_OBJECT_SUFFIX);
+		if (p && mdonly && strlen(p) == strlen(SNAPVIEW_OBJECT_SUFFIX)) {
+			ccow_release(c);
+			log_error(lg, "clone of a snapview object which belong to a remote site is NOT possible");
+			return -EAFNOSUPPORT;
+		}
+
+		/* Issue an object Clone! */
+		err = ccow_clone_version(c, tid_src, tid_src_size, bid_src, bid_src_size,
+		    oid_src, oid_src_size, &copy_opts, &sv->sv_vm_chid, &sv->sv_vm_nhid);
+		if (err) {
+			ccow_release(c);
+			log_error(lg, "CCOW_CLONE scheduling failure: %d", err);
+			return err;
+		}
+
+		err = ccow_wait(c, io_idx++);
+		if (err) {
+			log_error(lg, "snapview_clone returned failure: %d", err);
+			return err;
+		}
+	} else {
+		/* Cloning of a bucket snapshot.
+		 * Create a destination bucket that inherits source bucket properties.
+		 */
+		err = ccow_bucket_create(tc, bid_dst, bid_dst_size, c);
+		if (err) {
+			log_error(lg, "clone: bucket create error %d", err);
+			return err;
+		}
+		char last_obj[PATH_MAX] = {0};
+		int cloned_total = 0;
+		for (;;) {
+			/* For each object in a bucket snapshot doing an object clone operation */
+			ccow_lookup_t iter = NULL;
+			struct iovec iov;
+			int idx = 0, cloned = 0;
+
+			iov.iov_base = last_obj;
+			iov.iov_len = strlen(last_obj) + 1;
+
+			ccow_completion_t c1;
+			int c1_idx = 0;
+			err = ccow_create_completion(tc, NULL, NULL, mdonly ? 202: 101, &c1);
+			if (err) {
+				log_error(lg, "Bucket clone: completion create error %d", err);
+				goto _release;
+			}
+
+			if (mdonly)
+				c1->isgw_bid = sv_hdl->sv_bid;
+			else
+				c1->isgw_bid = NULL;
+
+			err = ccow_tenant_get_version(tc->cid, tc->cid_size, tc->tid,
+				tc->tid_size, bid_src, bid_src_size, "", 1, c1, &iov, 1,
+				100, CCOW_GET_LIST, &iter, &sv->sv_vm_chid, &sv->sv_vm_nhid);
+			if (err) {
+				log_error(lg, "Bucket clone: Source bucket list error %d", err);
+				goto _release;
+			}
+
+			err = ccow_wait(c1, c1_idx++);
+			if (err) {
+				log_error(lg, "Bucket clone: Source bucket list wait error %d", err);
+				goto _release;
+			}
+
+			struct ccow_metadata_kv *kv = NULL;
+			while ((kv = ccow_lookup_iter(iter, CCOW_MDTYPE_NAME_INDEX, idx++)) != NULL) {
+				if (!strcmp(kv->key, last_obj))
+					continue;
+
+				/* Don't clone mdonly snapview objects because the will loose their segment context */
+				if (mdonly) {
+					char* p = strstr(kv->key, SNAPVIEW_OBJECT_SUFFIX);
+					if (p && strlen(p) == strlen(SNAPVIEW_OBJECT_SUFFIX))
+						continue;
+				}
+
+				strcpy(last_obj, kv->key);
+				msgpack_u u;
+				msgpack_unpack_init_b(&u, kv->value, kv->value_size, 0);
+				uint8_t ver = 0, deleted = 0;
+				uint64_t ts = 0, gen = 0;
+				uint512_t vmchid, nhid;
+				err = msgpack_unpack_uint8(&u, &ver);
+				if (err) {
+					log_error(lg, "Bucket clone: entry unpack error %d", err);
+					goto _release;
+				}
+
+				err = msgpack_unpack_uint8(&u, &deleted);
+				if (err) {
+					log_error(lg, "Bucket clone: entry unpack error %d", err);
+					goto _release;
+				}
+				/* Don't clone deleted objects */
+				if (deleted)
+					continue;
+
+				err = msgpack_unpack_uint64(&u, &ts);
+				if (err) {
+					log_error(lg, "Bucket clone: entry unpack error %d", err);
+					goto _release;
+				}
+
+				err = msgpack_unpack_uint64(&u, &gen);
+				if (err) {
+					log_error(lg, "Bucket clone: entry unpack error %d", err);
+					goto _release;
+				}
+
+				err = replicast_unpack_uint512(&u, &vmchid);
+				if (err) {
+					log_error(lg, "Bucket clone: entry unpack error %d", err);
+					goto _release;
+				}
+
+				ccow_calc_nhid(tc->cid, tc->tid, bid_src, kv->key, &nhid);
+
+				log_debug(lg, "Cloning object %s, del %u, ts %lu, gen %lu, vmchid %016lX, NHID %016lX",
+					kv->key, deleted, ts, gen, vmchid.u.u.u, nhid.u.u.u);
+				if (mdonly) {
+					/* The mdonly snapshot is a trigger to pre-fetch all VMs it references
+					 * because they reside on a remote site
+					 */
+					err = ccow_clone_vm_prefetch(tc, &vmchid, &nhid,
+						tc->tid, tc->tid_size, bid_src, bid_src_size,
+						kv->key, strlen(kv->key) + 1, mdonly, c1);
+					if (err) {
+						log_error(lg, "mdonly bucket clone: VM prefetch error: %s/%s/%s/%s, vmchid %016lX, NHID %016lX",
+							tc->cid, tc->tid, bid_src, kv->key, vmchid.u.u.u, nhid.u.u.u);
+						goto _release;
+					}
+					err = ccow_wait(c1, c1_idx++);
+					if (err) {
+						log_error(lg, "mdonly bucket clone wait: VM prefetch error: %s/%s/%s/%s, vmchid %016lX, NHID %016lX",
+							tc->cid, tc->tid, bid_src, kv->key, vmchid.u.u.u, nhid.u.u.u);
+						goto _release;
+					}
+				}
+
+				/* Issue an object Clone! */
+				copy_opts.oid = kv->key;
+				copy_opts.oid_size = strlen(kv->key) + 1;
+				err = ccow_clone_version(c1, tc->tid, tc->tid_size, bid_src,
+					bid_src_size, kv->key, strlen(kv->key)+1,
+					&copy_opts, &vmchid, &nhid);
+				if (err) {
+					log_error(lg, "CCOW_CLONE bucket clone failed for object %s: %d", kv->key, err);
+					goto _release;
+				}
+				err = ccow_wait(c1, c1_idx++);
+				if (err) {
+					log_error(lg, "snapview_clone ccow_wait(%d) failure: %d", idx, err);
+					goto _release;
+				}
+				cloned++;
+			}
+
+_release:
+			ccow_release(c1);
+			if (iter)
+				ccow_lookup_release(iter);
+
+			if (!cloned || err) {
+				if (err)
+					log_error(lg, "Object %s/%s/%s/%s clone error %d",
+						tc->cid, tid_src, bid_src, last_obj, err);
+				break;
+			}
+			cloned_total += cloned;
+		}
 		ccow_release(c);
-		log_error(lg, "CCOW_CLONE scheduling failure: %d", err);
-		return err;
+		log_info(lg, "Cloned %d objects", cloned_total);
 	}
-
-	err = ccow_wait(c, 1);
-	if (err) {
-		log_error(lg, "snapview_clone returned failure: %d", err);
-		return err;
-	}
-
-	return 0;
+	return err;
 }
 
 /*
@@ -521,53 +867,6 @@ ccow_snapview_destroy(ccow_t tctx, ccow_snapview_t sv_hdl)
 	je_free(sv_hdl);
 	return;
 }
-
-/*
- * SCOPE: Public
- *
- * List the stored contents of a snapview.
- * @param sv_hdl snapview handle
- * Return zero on success, error otherwise.
- */
-int
-ccow_snapshot_lookup(ccow_t tctx, ccow_snapview_t sv_hdl,
-    const char *pattern, size_t p_size, size_t count, ccow_lookup_t *iter)
-{
-	assert(sv_hdl);
-
-	int err;
-	struct ccow *tc = tctx;
-	ccow_completion_t c;
-
-	if (pattern && p_size == 0)
-		return -EINVAL;
-
-	err = ccow_create_completion(tc, NULL, NULL, 1, &c);
-	if (err)
-		return err;
-
-	char buf[CCOW_CLUSTER_CHUNK_SIZE];
-	struct iovec iov = { .iov_base = buf };
-	memcpy(iov.iov_base, pattern, p_size);
-	iov.iov_len = p_size;
-	err = ccow_get_list(sv_hdl->sv_bid, sv_hdl->sv_bid_size, sv_hdl->sv_oid,
-	    sv_hdl->sv_oid_size, c, &iov, 1, count, iter);
-	if (err) {
-		ccow_release(c);
-		return err;
-	}
-
-	err = ccow_wait(c, -1);
-	if (err) {
-		if (iter && *iter) {
-			ccow_lookup_release(*iter);
-			*iter = NULL;
-		}
-		log_error(lg, "Error while reading snapview object %d", err);
-	}
-	return err;
-}
-
 
 /*
  * SCOPE: Public

--- a/src/ccow/src/libccowfsio/fsio_inode.c
+++ b/src/ccow/src/libccowfsio/fsio_inode.c
@@ -2764,7 +2764,6 @@ ccowfs_inode_clone_get(ccowfs_inode *src_inode, ci_t *dest_ci,
 	copy_opts.oid_size = inode->oid_size;
 	copy_opts.genid = NULL;
 	copy_opts.version_uvid_timestamp = 0;
-	copy_opts.version_vm_content_hash_id = NULL;
 
 	err = ccowfs_create_completion(inode->ci, NULL, NULL, src_inode->ino,
 	    &c);

--- a/src/ccow/src/libreplicast/replicast.h
+++ b/src/ccow/src/libreplicast/replicast.h
@@ -396,6 +396,7 @@ struct replicast_datagram_hdr {
 #define RD_ATTR_ONDEMAND_CLONE          0x0004000000000000UL /* Put a cloned object as local */
 #define RD_ATTR_ONDEMAND_PREFETCH       0x0008000000000000UL /* A get operation is triggered in order to pre-fetch a cacheable object from remote */
 #define RD_ATTR_CHUNK_LOOKUP            0x0010000000000000UL /* A chunk lookup request */
+#define RD_ATTR_SNAPSHOT                0x0020000000000000UL /* A snapshot insert request */
         uint64_t attributes;
         uint8_t hash_type;                /* payload hash type */
 	uint64_t fh_genid;		/* flexhash genid */

--- a/src/ccow/src/libreptrans/Makefile.am
+++ b/src/ccow/src/libreptrans/Makefile.am
@@ -39,7 +39,7 @@ libreptrans_la_SOURCES = reptrans-data.c reptrans.c named-put.c unnamed-put.c \
 			 vmm_cache.c recovery-srv.c rt_locks.c \
 			 rcvd_cache.c opp-status-srv.c serial_op.c gwcache-get.c \
 			 gwcache-async.c reptrans-flex.c rowevac-srv.c sop_list.c \
-			 res-get.c
+			 res-get.c compat.c
 
 libreptrans_la_CFLAGS = -I$(top_srcdir)/src/libflexhash \
 			-I$(top_srcdir)/src/libreplicast \

--- a/src/ccow/src/libreptrans/compat.c
+++ b/src/ccow/src/libreptrans/compat.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015-2018 Nexenta Systems, inc.
+ *
+ * This file is part of EdgeFS Project
+ * (see https://github.com/Nexenta/edgefs).
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ * Put here any temporary code which will be removed in further versions
+ * and provide backward-compatibility functions
+ *
+ */
+#include "reptrans.h"
+#include "reptrans-data.h"
+
+/* Keep the old verification request here for a while for backward compatibility reason */
+struct verification_request_v1 {
+	uint512_t chid;
+	uint512_t nhid;
+	uint128_t target_vdevid;
+	uint64_t uvid_timestamp;
+	uint64_t generation;
+	struct backref vbr;
+	uint8_t vtype;
+	uint8_t ttag;
+	uint8_t htype;
+	uint8_t width;
+	uint8_t n_parity;
+	uint8_t domain;
+	uint8_t algorithm;
+};
+
+int
+vbreq_convert_compat(void* data_ptr,  struct verification_request** out) {
+	/* Convert verification/enconding/batch queue entries to new format */
+	struct verification_request_v1* vold = data_ptr;
+	if (vold->ttag != TT_VERSION_MANIFEST && vold->ttag != TT_CHUNK_MANIFEST)
+		return -EINVAL;
+	struct verification_request* vbreq = je_calloc(1, sizeof(struct verification_request));
+	if (!vbreq)
+		return -ENOMEM;
+	vbreq->algorithm = vold->algorithm;
+	vbreq->chid = vold->chid;
+	vbreq->domain = vold->domain;
+	vbreq->generation = vold->generation;
+	vbreq->htype = vold->htype;
+	vbreq->n_parity = vold->n_parity;
+	vbreq->nhid = vold->nhid;
+	vbreq->target_vdevid = vold->target_vdevid;
+	vbreq->ttag = vold->ttag;
+	vbreq->uvid_timestamp = vold->uvid_timestamp;
+	vbreq->vbr = vold->vbr;
+	vbreq->vtype = vold->vtype;
+	vbreq->width = vold->width;
+	*out = vbreq;
+	return 0;
+}
+
+
+

--- a/src/ccow/src/libreptrans/compat.h
+++ b/src/ccow/src/libreptrans/compat.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015-2018 Nexenta Systems, inc.
+ *
+ * This file is part of EdgeFS Project
+ * (see https://github.com/Nexenta/edgefs).
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef SRC_LIBREPTRANS_COMPAT_H_
+#define SRC_LIBREPTRANS_COMPAT_H_
+
+/* Convert entries from TT_VERIFICATION_QUEUE, TT_BATCH_QUEUE and TT_ENCODING_QUEUE
+ * from previous to new on-disk format
+ */
+int
+vbreq_convert_compat(void* data_ptr,  struct verification_request** out);
+
+
+
+#endif /* SRC_LIBREPTRANS_COMPAT_H_ */

--- a/src/ccow/src/libreptrans/named-put.c
+++ b/src/ccow/src/libreptrans/named-put.c
@@ -831,6 +831,10 @@ namedput_srv_exec(void *arg)
 			return;
 		}
 	} else {
+		if (*req->md.cid != 0 && *req->md.tid != 0 && *req->md.bid != 0 && *req->md.oid == 0)
+			vbreq.vtype |= RT_VERIFY_BUCKET;
+		if (msg_pp->hdr.attributes & RD_ATTR_SNAPSHOT)
+			vbreq.vtype |= RT_VERIFY_SNAPSHOT;
 		uint16_t mdonly_policy = RT_ONDEMAND_GET(req->md.inline_data_flags);
 		if (mdonly_policy != ondemandPolicyLocal) {
 			/* cacheable objects have to bypass quarantine */

--- a/src/ccow/src/libreptrans/rtkvs/reptrans-kvs.c
+++ b/src/ccow/src/libreptrans/rtkvs/reptrans-kvs.c
@@ -3843,10 +3843,12 @@ kvs_iterate_blobs_strict(struct repdev *dev, type_tag_t ttag,
 			total += dstat.ms_entries;
 			mdb_txn_abort(txn);
 		}
-		if (!total)
-			return 0;
-		for (int j = 0; j < kvs->plevel; j++)
-			blobs_dist[j] = 1LL + blobs_dist[j] * (long long)max_blobs / total;
+		for (int j = 0; j < kvs->plevel; j++) {
+			if (total)
+				blobs_dist[j] = 1LL + blobs_dist[j] * (long long)max_blobs / total;
+			else
+				blobs_dist[j] = 0;
+		}
 	} else {
 		for (int j = 0; j < kvs->plevel; j++)
 			blobs_dist[j] = -1;
@@ -3868,6 +3870,9 @@ kvs_iterate_blobs_strict(struct repdev *dev, type_tag_t ttag,
 			if (err)
 				break;
 		}
+
+		if (!blobs_dist[j])
+			continue;
 
 		err = kvs_iterate_blobs_shard(dev, ttag,
 		    callback, param, want_values,

--- a/src/ccow/src/libreptrans/rtlfs/reptrans-lfs.c
+++ b/src/ccow/src/libreptrans/rtlfs/reptrans-lfs.c
@@ -3741,10 +3741,12 @@ lfs_iterate_blobs_strict(struct repdev *dev, type_tag_t ttag,
 			total += dstat.ms_entries;
 			mdb_txn_abort(txn);
 		}
-		if (!total)
-			return 0;
-		for (int j = 0; j < lfs->plevel; j++)
-			blobs_dist[j] = 1LL + (long long)blobs_dist[j] * max_blobs / total;
+		for (int j = 0; j < lfs->plevel; j++) {
+			if (total)
+				blobs_dist[j] = 1LL + (long long)blobs_dist[j] * max_blobs / total;
+			else
+				blobs_dist[j] = 0;
+		}
 	} else for (int j = 0; j < lfs->plevel; j++)
 		blobs_dist[j] = -1;
 
@@ -3763,6 +3765,9 @@ lfs_iterate_blobs_strict(struct repdev *dev, type_tag_t ttag,
 			if (err)
 				break;
 		}
+
+		if (!blobs_dist[j])
+			continue;
 
 		err = lfs_iterate_blobs_shard(dev, ttag,
 		    callback, param, want_values,

--- a/src/ccow/test/Makefile.am
+++ b/src/ccow/test/Makefile.am
@@ -468,7 +468,14 @@ clone_test_LDADD = $(top_srcdir)/src/libccowutil/libccowutil.la \
 
 get_test_SOURCES = get_test.c cmocka.c common.c
 get_test_LDFLAGS = $(AM_LDFLAGS) -luv -lcrypto -lccow
-get_test_CFLAGS = -fPIC -g -std=gnu99
+get_test_CFLAGS = -fPIC -g -std=gnu99 \
+		-I$(top_srcdir)/src/libflexhash \
+		-I$(top_srcdir)/src/libreptrans \
+		-I$(top_srcdir)/src/libreplicast \
+		-I$(top_srcdir)/src/libtrlog \
+		-I$(top_srcdir)/src/libccowd \
+		-I$(top_srcdir)/src/libccow
+
 get_test_LDADD = $(top_srcdir)/src/libccowutil/libccowutil.la \
 		 $(top_srcdir)/src/libccowd/libccowd.la -luv -lcrypto $(ASAN_LIB)
 

--- a/src/ccow/test/clone_test.c
+++ b/src/ccow/test/clone_test.c
@@ -110,7 +110,6 @@ clone_test__clone_0_1k(void **state)
 	copy_opts.oid_size = strlen(cloned_name) + 1;
 	copy_opts.genid = NULL;
 	copy_opts.version_uvid_timestamp = 0;
-	copy_opts.version_vm_content_hash_id = NULL;
 
 
 	err = ccow_clone(c, "test", 5, TEST_BUCKET_NAME, strlen(TEST_BUCKET_NAME) + 1,
@@ -141,7 +140,6 @@ clone_test__clone_to_self(void **state)
 	copy_opts.oid_size = strlen(source_name) + 1;
 	copy_opts.genid = NULL;
 	copy_opts.version_uvid_timestamp = 0;
-	copy_opts.version_vm_content_hash_id = NULL;
 
 	err = ccow_clone(c, "test", 5, TEST_BUCKET_NAME, strlen(TEST_BUCKET_NAME) + 1,
 	    source_name, strlen(source_name) + 1, &copy_opts);
@@ -278,7 +276,6 @@ clone_test_override(void **state)
 	copy_opts.oid_size = strlen(cloned_override_name2) + 1;
 	copy_opts.genid = NULL;
 	copy_opts.version_uvid_timestamp = 0;
-	copy_opts.version_vm_content_hash_id = NULL;
 
 	uint64_t value1 = REPLICATION_COUNT_OVERRIDE2;
 	err = ccow_attr_modify_md_overrides(c, RT_SYSKEY_REPLICATION_COUNT, value1);

--- a/src/ccow/test/put_file.c
+++ b/src/ccow/test/put_file.c
@@ -296,7 +296,6 @@ clone_test(void **state)
 	copy_opts.oid_size = strlen(clone_path) + 1;
 	copy_opts.genid = NULL;
 	copy_opts.version_uvid_timestamp = 0;
-	copy_opts.version_vm_content_hash_id = NULL;
 	printf("Clonning %s -> %s\n", object_name, clone_path);
 	err = ccow_clone(c, "test", 5, bucket_name, strlen(bucket_name) + 1,
 		object_name, strlen(object_name) + 1, &copy_opts);

--- a/src/ccow/test/versions_test.c
+++ b/src/ccow/test/versions_test.c
@@ -162,7 +162,6 @@ clone_test_clone(void **state)
 	copy_opts.oid_size = strlen(object_copy) + 1;
 	copy_opts.genid = &genid_version;
 	copy_opts.version_uvid_timestamp = version_uvid_timestamp;
-	copy_opts.version_vm_content_hash_id = version_vm_content_hash_id;
 
 
 	err = ccow_clone(c, "test", 5, TEST_BUCKET_NAME, strlen(TEST_BUCKET_NAME) + 1,

--- a/src/efscli/main.go
+++ b/src/efscli/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Nexenta/edgefs/src/efscli/cluster"
 	"github.com/Nexenta/edgefs/src/efscli/config"
 	"github.com/Nexenta/edgefs/src/efscli/object"
+	"github.com/Nexenta/edgefs/src/efscli/snapshot"
 	"github.com/Nexenta/edgefs/src/efscli/service"
 	"github.com/Nexenta/edgefs/src/efscli/system"
 	"github.com/Nexenta/edgefs/src/efscli/tenant"
@@ -56,6 +57,7 @@ func main() {
 	efscliCmd.AddCommand(config.ConfigCmd)
 	efscliCmd.AddCommand(user.UserCmd)
 	efscliCmd.AddCommand(device.DeviceCommand)
+	efscliCmd.AddCommand(snapshot.SnapshotCmd)
 
 	if err := efscliCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/src/efscli/object/clone.go
+++ b/src/efscli/object/clone.go
@@ -56,7 +56,7 @@ func objectClone(srcpath string, dstpath string, flags []efsutil.FlagValue) erro
 
 	bucket, errb := efsutil.GetMDPat(d[0], d[1], d[2], "", "")
 	if errb != nil {
-		return errb
+		return fmt.Errorf("GetMDPat error for %v/%v/%v: %v", d[0], d[1], d[2], errb)
 	}
 
 	c_cluster_s := C.CString(s[0])
@@ -177,8 +177,6 @@ func objectClone(srcpath string, dstpath string, flags []efsutil.FlagValue) erro
 	opts.oid = c_object_d
 	opts.oid_size = C.strlen(c_object_d) + 1
 	opts.genid = nil
-	opts.version_vm_content_hash_id = nil
-	opts.vm_chid = nil
 	opts.md_override = 1;
 
 	ret = C.ccow_clone(c, c_tenant_s, C.strlen(c_tenant_s)+1, c_bucket_s,
@@ -204,6 +202,12 @@ func objectClone(srcpath string, dstpath string, flags []efsutil.FlagValue) erro
 var (
 	flagsClone []efsutil.FlagValue
 
+	flagNamesClone = []string {
+		"ec-data-mode",
+		"ec-trigger-policy-timeout",
+		"options",
+	}
+
 	cloneCmd = &cobra.Command{
 		Use:   "clone  <cluster>/<tenant>/<bucket>/<object> <cluster>/<tenant>/<bucket>/<object>",
 		Short: "clone an object",
@@ -220,8 +224,8 @@ var (
 )
 
 func init() {
-	flagsClone = make([]efsutil.FlagValue, len(flagNames))
-	efsutil.ReadAttributes(cloneCmd, flagNames, flagsClone)
+	flagsClone = make([]efsutil.FlagValue, len(flagNamesClone))
+	efsutil.ReadAttributes(cloneCmd, flagNamesClone, flagsClone)
 	ObjectCmd.AddCommand(cloneCmd)
 }
 

--- a/src/efscli/snapshot/add.go
+++ b/src/efscli/snapshot/add.go
@@ -21,7 +21,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package object
+package snapshot
 
 /*
 #include "ccow.h"
@@ -36,14 +36,14 @@ import (
 	"strings"
 
 	"github.com/Nexenta/edgefs/src/efscli/efsutil"
-	//"github.com/Nexenta/edgefs/src/efscli/validate"
 	"github.com/spf13/cobra"
 )
 
-func snapshotRm(snapViewPath, sourceSnapshotPath string, flags []efsutil.FlagValue) error {
+func snapshotAdd(snapViewPath, sourceSnapshotPath string,  flags []efsutil.FlagValue) error {
 
 	c_svPath := C.CString(snapViewPath)
 	defer C.free(unsafe.Pointer(c_svPath))
+
 
 	// SnapView path parts
 	snapPathParts := strings.SplitN(snapViewPath, "/", 4)
@@ -76,7 +76,10 @@ func snapshotRm(snapViewPath, sourceSnapshotPath string, flags []efsutil.FlagVal
 	c_ssBucket := C.CString(snapshotObjectPath[2])
 	defer C.free(unsafe.Pointer(c_ssBucket))
 
-	c_ssObject := C.CString(snapshotObjectPath[3])
+	c_ssObject := C.CString("")
+	if  len(snapshotObjectPath) > 3 {
+		c_ssObject = C.CString(snapshotObjectPath[3])
+	}
 	defer C.free(unsafe.Pointer(c_ssObject))
 
 	// Libccow Init
@@ -97,17 +100,12 @@ func snapshotRm(snapViewPath, sourceSnapshotPath string, flags []efsutil.FlagVal
 	}
 	defer C.ccow_tenant_term(svtc)
 
-	var svc C.ccow_completion_t
-	ret = C.ccow_create_completion(svtc, nil, nil, 1, &svc)
-	if ret != 0 {
-		return fmt.Errorf("%s: snapview ccow_create_completion err=%d\n", efsutil.GetFUNC(), ret)
-	}
-
 	var snapview_t C.ccow_snapview_t
 	ret = C.ccow_snapview_create(svtc, &snapview_t, c_svBucket, C.strlen(c_svBucket)+1, c_svObject, C.strlen(c_svObject)+1)
 	if ret != 0 && ret != -C.EEXIST {
 		return fmt.Errorf("%s: snapView ccow_snapview_create err=%d\n", efsutil.GetFUNC(), ret)
 	}
+	defer C.ccow_snapview_destroy(svtc, snapview_t)
 
 	//Snapshot ccow_t
 	var sstc C.ccow_t
@@ -118,70 +116,61 @@ func snapshotRm(snapViewPath, sourceSnapshotPath string, flags []efsutil.FlagVal
 	}
 	defer C.ccow_tenant_term(sstc)
 
-	//Snapshot completion
-	var ssc C.ccow_completion_t
-	ret = C.ccow_create_completion(sstc, nil, nil, 1, &ssc)
+	ret = C.ccow_snapshot_create(sstc, snapview_t, c_ssBucket, C.strlen(c_ssBucket) + 1, c_ssObject, C.strlen(c_ssObject) + 1, c_snapshot, C.strlen(c_snapshot) + 1)
 	if ret != 0 {
-		return fmt.Errorf("%s: snapshot ccow_create_completion err=%d\n", efsutil.GetFUNC(), ret)
-	}
-
-	ret = C.ccow_snapshot_delete(sstc, snapview_t, c_snapshot, C.strlen(c_snapshot)+1)
-	if ret != 0 {
-		if ret == -C.ENOENT {
-			C.ccow_snapview_destroy(svtc, snapview_t)
-			fmt.Printf("Snapshot %s not exists in the snapview %s\n", sourceSnapshotPath, snapViewPath)
+		if ret == -C.EEXIST {
+			fmt.Printf("Snapshot %s already exists in the snapview %s\n", sourceSnapshotPath, snapViewPath)
 			return nil
 		}
 
-		return fmt.Errorf("%s: snapshot ccow_snapshot_create=%d\n", efsutil.GetFUNC(), ret)
+		return fmt.Errorf("%s: snapshot ccow_snapshot_create=%d\n", efsutil.GetFUNC(),  ret)
 	}
 
-	fmt.Printf("Snapshot %s has been removed from %s\n", sourceSnapshotPath, snapViewPath)
-	defer C.ccow_snapview_destroy(svtc, snapview_t)
+	fmt.Printf("Snapshot %s has been added to %s\n", sourceSnapshotPath, snapViewPath)
 
 	return nil
 }
 
 var (
-	flagsSnapshotRm []efsutil.FlagValue
+	flagsSnapshotAdd []efsutil.FlagValue
 
-	snapshotRmCmd = &cobra.Command{
-		Use:   "snapshot-rm <snapViewPath> <snapshotPath>",
-		Short: "remove snapshot from snapview",
-		Long:  "remove snapshot from specified snapview object",
+	snapshotAddCmd = &cobra.Command{
+		Use:   "add object.snapview object-path@snapshot-name",
+		Short: "add a new object's snapshot to snapview",
+		Long:  "create a new object's snapshot and add it to existing snapview object",
 		//Args:  validate.Object,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			/*edgefs object snapshot-rm cl/tn/bk/ob@snapshotName cl/tn/bk/ob.snapview */
+			/*edgefs object snapshot-add cl/tn/bk/ob@snapshotName cl/tn/bk/ob.snapview */
 			if len(args) != 2 {
-				fmt.Printf("Wrong parameters: Should be 'edgefs object snapshot-rm <snapViewPath> <snapshotPath>'\n")
+				fmt.Printf("Wrong parameters: Should be 'efscli snpashot add <snapViewPath> <snapshot>'\n")
 				return
 			}
 
 			snapViewPathParts := strings.Split(args[0], "/")
 			if len(snapViewPathParts) != 4 {
-				fmt.Printf("Wrong snapview path: %s\n", args[1])
+				fmt.Printf("Wrong snapview path: %s\n", args[0])
 				return
 			}
 
 			if !strings.HasSuffix(args[0], EDGEFS_SNAPVIEW_SUFFIX) {
-				fmt.Printf("Not a snapview path: %s\n", args[1])
+				fmt.Printf("Not a snapview path: %s\n", args[0])
 				return
 			}
 
 			srcPathParts := strings.Split(args[1], "@")
 			if len(srcPathParts) != 2 {
-				fmt.Printf("Wrong object snapshot format %s. Should be <cluster>/<tenant>/<bucket>/<object>@<snapshotName>\n", args[0])
+				fmt.Printf("Wrong object snapshot format %s. Should be <cluster>/<tenant>/<bucket>[/<object>]@<snapshotName>\n", args[1])
 				return
 			}
 
 			pathParts := strings.Split(srcPathParts[0], "/")
-			if len(pathParts) != 4 {
-				fmt.Printf("Wrong object snapshot path: %s\n", srcPathParts[0])
+			if len(pathParts) < 3 {
+				fmt.Printf("Wrong object snapshot path: %s. You can create snapshot of a bucket or an object\n", srcPathParts[0])
 				return
 			}
 
-			err := snapshotRm(args[0], args[1], flagsSnapshotRm)
+			err := snapshotAdd(args[0], args[1], flagsSnapshotAdd)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
@@ -191,7 +180,5 @@ var (
 )
 
 func init() {
-	//flagsSnapshotRm = make([]efsutil.FlagValue, len(flagNames))
-	//efsutil.ReadAttributes(snapshotRmCmd, flagNames, flagsSnapshotRm)
-	ObjectCmd.AddCommand(snapshotRmCmd)
+	SnapshotCmd.AddCommand(snapshotAddCmd)
 }

--- a/src/efscli/snapshot/clone.go
+++ b/src/efscli/snapshot/clone.go
@@ -21,7 +21,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package object
+package snapshot
 
 /*
 #include "ccow.h"
@@ -36,7 +36,6 @@ import (
 	"strings"
 
 	"github.com/Nexenta/edgefs/src/efscli/efsutil"
-	//"github.com/Nexenta/edgefs/src/efscli/validate"
 	"github.com/spf13/cobra"
 )
 
@@ -74,7 +73,10 @@ func snapshotClone(snapViewPath, snapshotName, cloneObjectPath string, flags []e
 	c_cloneBucket := C.CString(cloneObjectParts[2])
 	defer C.free(unsafe.Pointer(c_cloneBucket))
 
-	c_cloneObject := C.CString(cloneObjectParts[3])
+	c_cloneObject := C.CString("")
+	if len (cloneObjectParts) > 3 {
+		c_cloneObject = C.CString(cloneObjectParts[3])
+	}
 	defer C.free(unsafe.Pointer(c_cloneObject))
 
 	// Libccow Init
@@ -159,15 +161,14 @@ var (
 	flagsSnapshotClone []efsutil.FlagValue
 
 	snapshotCloneCmd = &cobra.Command{
-		Use:   "snapshot-clone object.snapview snapshot cloneDestinationObject",
+		Use:   "clone object.snapview snapshot cloneDestinationObject",
 		Long:  "clone existing snapview's snapshot to a new destination object",
 		Short: "clone snapshot to object",
 		//Args:  validate.Object,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			/*edgefs object snapshot-add cl/tn/bk/ob@snapshotName cl/tn/bk/ob.snapview */
 			if len(args) != 3 {
-				fmt.Printf("Wrong parameters: Should be 'edgefs object snapshot-clone object.snapview snapshotPath cloneDestination'\n")
+				fmt.Printf("Wrong parameters: Should be 'efscli snapshot clone object.snapview snapshotPath cloneDestination'\n")
 				return
 			}
 
@@ -184,18 +185,18 @@ var (
 
 			snapshotParts := strings.Split(args[1], "@")
 			if len(snapshotParts) != 2 {
-				fmt.Printf("Wrong object snapshot format %s. Should be <cluster>/<tenant>/<bucket>/<object>@<name>\n", args[1])
+				fmt.Printf("Wrong object snapshot format %s. Should be <cluster>/<tenant>/<bucket>[/<object>]@<name>\n", args[1])
 				return
 			}
 
 			snapshotPathParts := strings.Split(snapshotParts[0], "/")
-			if len(snapshotPathParts) != 4 {
+			if len(snapshotPathParts) < 3 {
 				fmt.Printf("Wrong object snapshot path: %s", snapshotPathParts[0])
 				return
 			}
 
 			clonePathParts := strings.Split(args[2], "/")
-			if len(clonePathParts) != 4 {
+			if len(clonePathParts) < 3 {
 				fmt.Printf("Wrong clone destinaion path: %s", args[2])
 				return
 			}
@@ -210,7 +211,5 @@ var (
 )
 
 func init() {
-	//flagsSnapshotClone = make([]efsutil.FlagValue, len(flagNames))
-	//efsutil.ReadAttributes(snapshotCloneCmd, flagNames, flagsSnapshotClone)
-	ObjectCmd.AddCommand(snapshotCloneCmd)
+	SnapshotCmd.AddCommand(snapshotCloneCmd)
 }

--- a/src/efscli/snapshot/list.go
+++ b/src/efscli/snapshot/list.go
@@ -21,7 +21,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package object
+package snapshot
 
 /*
 #include "ccow.h"
@@ -36,15 +36,17 @@ import (
 	"strings"
 
 	"github.com/Nexenta/edgefs/src/efscli/efsutil"
-	//"github.com/Nexenta/edgefs/src/efscli/validate"
+	"github.com/Nexenta/edgefs/src/efscli/validate"
 	"github.com/spf13/cobra"
 )
 
-func snapshotRollback(snapViewPath, snapshotName string) error {
+func snapshotList(snapViewPath, pattern string, count uint32, flags []efsutil.FlagValue) error {
+
+	c_pattern := C.CString(pattern)
+	defer C.free(unsafe.Pointer(c_pattern))
 
 	// SnapView path parts
 	snapPathParts := strings.SplitN(snapViewPath, "/", 4)
-
 	c_svCluster := C.CString(snapPathParts[0])
 	defer C.free(unsafe.Pointer(c_svCluster))
 
@@ -56,9 +58,6 @@ func snapshotRollback(snapViewPath, snapshotName string) error {
 
 	c_svObject := C.CString(snapPathParts[3])
 	defer C.free(unsafe.Pointer(c_svObject))
-	
-	// Snapshot name
-	c_shName := C.CString(snapshotName)
 
 	// Libccow Init
 	conf, err := efsutil.GetLibccowConf()
@@ -78,34 +77,76 @@ func snapshotRollback(snapViewPath, snapshotName string) error {
 	}
 	defer C.ccow_tenant_term(svtc)
 
+	var svc C.ccow_completion_t
+	ret = C.ccow_create_completion(svtc, nil, nil, 1, &svc)
+	if ret != 0 {
+		return fmt.Errorf("%s: snapview ccow_create_completion err=%d\n", efsutil.GetFUNC(), ret)
+	}
 
 	var snapview_t C.ccow_snapview_t
-	ret = C.ccow_snapview_new(&snapview_t, c_svBucket, C.strlen(c_svBucket)+1, c_svObject, C.strlen(c_svObject)+1)
+
+	ret = C.ccow_snapview_create(svtc, &snapview_t, c_svBucket, C.strlen(c_svBucket)+1, c_svObject, C.strlen(c_svObject)+1)
 	if ret != 0 && ret != -C.EEXIST {
 		return fmt.Errorf("%s: snapView ccow_snapview_create err=%d\n", efsutil.GetFUNC(), ret)
 	}
 	defer C.ccow_snapview_destroy(svtc, snapview_t)
 
-	ret = C.ccow_snapshot_rollback(svtc, snapview_t, c_shName, C.strlen(c_shName)+1)
-	if ret != 0 && ret != -C.EEXIST {
-		return fmt.Errorf("%s: snapshot rollback error: %d\n", efsutil.GetFUNC(), ret)
+	var snapshotIterator C.ccow_lookup_t
+
+	ret = C.ccow_snapshot_lookup(svtc, snapview_t, c_pattern, C.strlen(c_pattern)+1, C.ulong(count), &snapshotIterator)
+	if ret != 0 {
+		if snapshotIterator != nil {
+			C.ccow_lookup_release(snapshotIterator)
+		}
+
+		if ret == -C.ENOENT {
+			return nil
+		}
+
+		return fmt.Errorf("ccow_snapshot_lookup err=%d\n", ret)
 	}
+
+	var kv *C.struct_ccow_metadata_kv
+	for {
+		kv = (*C.struct_ccow_metadata_kv)(C.ccow_lookup_iter(snapshotIterator, C.CCOW_MDTYPE_NAME_INDEX, -1))
+		if kv == nil {
+			break
+		}
+		if kv.key_size == 0 {
+			continue
+		}
+
+		if strings.HasPrefix(C.GoString(kv.key), pattern) {
+			//found = 1
+			if !efsutil.IsSystemName(C.GoString(kv.key)) {
+				fmt.Printf("%s\n", C.GoString(kv.key))
+			}
+			continue
+		}
+	}
+	C.ccow_lookup_release(snapshotIterator)
+
 	return nil
 }
 
 var (
+	flagsSnapshotList []efsutil.FlagValue
 
-	snapshotRollbackCmd = &cobra.Command{
-		Use:   "snapshot-rollback <snapview-path> <snapshot>",
-		Long:  "rollback existing snapview's snapshot",
-		Short: "rollback a snapshot",
-		//Args:  validate.Object,
+	snapshotListCmd = &cobra.Command{
+		Use:   "list snapViewPath <namePattern>",
+		Short: "list snapshots of specified snapview object",
+		Long:  "list snapshots of specified snapview object",
+		Args:  validate.Object,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			/*edgefs object snapshot-rollback <cl/tn/bk/ob>.snapview <snapshotName> */
-			if len(args) != 2 {
-				fmt.Printf("Wrong parameters: Should be 'edgefs object snapshot-rollback <cl/tn/bk/sv.snapview> <snapshotName>'\n")
+			if len(args) < 1 {
+				fmt.Printf("Wrong parameters: Should be 'efscli snapshot list <snapViewPath>'")
 				return
+			}
+
+			var pattern string
+			if len(args) >= 2 {
+				pattern = args[1]
 			}
 
 			snapViewPathParts := strings.Split(args[0], "/")
@@ -115,11 +156,11 @@ var (
 			}
 
 			if !strings.HasSuffix(args[0], EDGEFS_SNAPVIEW_SUFFIX) {
-				fmt.Printf("Not a snapview path: %s", args[0])
+				fmt.Printf("Not a snapview path: %s", args[1])
 				return
 			}
 
-			err := snapshotRollback(args[0], args[1])
+			err := snapshotList(args[0], pattern, 1000000, flagsSnapshotList)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
@@ -129,7 +170,5 @@ var (
 )
 
 func init() {
-	ObjectCmd.AddCommand(snapshotRollbackCmd)
+	SnapshotCmd.AddCommand(snapshotListCmd)
 }
-
-

--- a/src/efscli/snapshot/snapshot.go
+++ b/src/efscli/snapshot/snapshot.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015-2018 Nexenta Systems, Inc.
+ *
+ * This file is part of EdgeFS Project
+ * (see https://github.com/Nexenta/edgefs).
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package snapshot
+
+/*
+#include "ccow.h"
+*/
+import "C"
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagNames = []string {
+		"chunk-size",
+		"number-of-versions",
+		"replication-count",
+		"sync-put",
+		"select-policy",
+		"ec-data-mode",
+		"ec-trigger-policy-timeout",
+		"encryption-enabled",
+		"options",
+	}
+
+	SnapshotCmd = &cobra.Command{
+		Use:     "snapshot",
+		Aliases: []string{"o"},
+		Short:   "Snapshot operations",
+		Long:    "Snapshot operations, e.g. create, delete, rollback, clone",
+	}
+)
+
+func init() {
+}

--- a/src/efscli/snapshot/snapview-create.go
+++ b/src/efscli/snapshot/snapview-create.go
@@ -21,7 +21,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package object
+package snapshot
 
 /*
 #include "ccow.h"
@@ -34,7 +34,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
 	"github.com/Nexenta/edgefs/src/efscli/efsutil"
 	"github.com/Nexenta/edgefs/src/efscli/validate"
 	"github.com/spf13/cobra"
@@ -132,7 +131,5 @@ var (
 )
 
 func init() {
-	//flagsSnapViewCreate = make([]efsutil.FlagValue, len(flagNames))
-	//efsutil.ReadAttributes(snapViewCreateCmd, flagNames, flagsSnapViewCreate)
-	ObjectCmd.AddCommand(snapViewCreateCmd)
+	SnapshotCmd.AddCommand(snapViewCreateCmd)
 }

--- a/src/efscli/snapshot/snapview-delete.go
+++ b/src/efscli/snapshot/snapview-delete.go
@@ -21,7 +21,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package object
+package snapshot
 
 /*
 #include "ccow.h"
@@ -83,7 +83,7 @@ func snapViewDelete(opath string, flags []efsutil.FlagValue) error {
 	}
 
 	var snapview_t C.ccow_snapview_t
-        ret = C.ccow_snapview_create(tc, &snapview_t, c_bucket, C.strlen(c_bucket) + 1, c_object, C.strlen(c_object) + 1)
+	ret = C.ccow_snapview_create(tc, &snapview_t, c_bucket, C.strlen(c_bucket) + 1, c_object, C.strlen(c_object) + 1)
 	if ret != 0 {
 		if ret != -C.EEXIST {
 			return fmt.Errorf("%s: ccow_snapview_create err=%d", efsutil.GetFUNC(), ret)
@@ -93,8 +93,8 @@ func snapViewDelete(opath string, flags []efsutil.FlagValue) error {
 
 	ret = C.ccow_snapview_delete(tc, snapview_t)
 	if ret != 0 {
-                return fmt.Errorf("%s: ccow_snapview_delete err=%d", efsutil.GetFUNC(), ret)
-        }
+		return fmt.Errorf("%s: ccow_snapview_delete err=%d", efsutil.GetFUNC(), ret)
+	}
 
 	return nil
 }
@@ -130,7 +130,5 @@ var (
 )
 
 func init() {
-	//flagsSnapViewDelete = make([]efsutil.FlagValue, len(flagNames))
-	//efsutil.ReadAttributes(snapViewDeleteCmd, flagNames, flagsSnapViewDelete)
-	ObjectCmd.AddCommand(snapViewDeleteCmd)
+	SnapshotCmd.AddCommand(snapViewDeleteCmd)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
Added bucket snapshot support. The most important changes:

1. Bucket's refEntry has its CHID field pointing to VM CHID of an object referenced by this entry. Prior bucket object implementation had an empty CHID filed. Important: top-down bucket verification does NOT cross the boundary of a bucket object. That is, the referenced object isn't verified in the context of bucket verification.
2. Object verification code has changed according to p.1
3. Space reclaim background job changed in order to properly process bucket objects.
4. Bucket snapshot rollback isn't supported. Use a bucket snapshot clone instead. The destination bucket must be empty or absent.
5. Changed tenant get/put/clone base functions. Added capability to get/put/clone an object which doesn't have an entry in a namespace table (the name index). Such an object can be referenced by its VM CHID.
6. Added bucket clone support to libccow
7. Added a set of commands for snapshot/snapview management: `efscli snapshot .....` Some of those functions were moved from `efscli object ...` sub-command.
8. A fix in the strict iterator.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #222

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
