### PR TITLE
Issue 407

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -11,7 +11,7 @@ ulimit -c unlimited
 ulimit -n 65536
 
 # CCOW Daemon needs more memory on stack
-ulimit -s 32768
+ulimit -s 16384
 
 LDFLAGS=-L$NEDGE_HOME/lib; export LDFLAGS
 CFLAGS="-I$NEDGE_HOME/include -I$NEDGE_HOME/include/ccow"; export CFLAGS

--- a/src/ccow/src/libccowd/ccowd.c
+++ b/src/ccow/src/libccowd/ccowd.c
@@ -2269,12 +2269,18 @@ ccow_daemon_init(struct ccowd_params *params)
 	}
 #endif
 
-	const rlim_t stack_size = 32L * 1024L * 1024L;
+	rlim_t stack_size = 16L * 1024L * 1024L;
+	char* ss_str = getenv("CCOWD_STACK_SIZE");
+	if (ss_str) {
+		size_t ss = strtoll(ss_str, NULL, 10);
+		if (ss)
+			stack_size = ss;
+	}
 	struct rlimit stack_limits;
 	int res = getrlimit(RLIMIT_STACK, &stack_limits);
 
 	if (res == 0) {
-		if (stack_limits.rlim_cur < stack_size) {
+		if (stack_limits.rlim_cur != stack_size) {
 			log_info(lg, "stack size was %d", (int) stack_limits.rlim_cur);
 			log_info(lg, "setting stack size to %d", (int) stack_size);
 			stack_limits.rlim_cur = stack_size;

--- a/src/ccow/src/libccowd/serverid.c
+++ b/src/ccow/src/libccowd/serverid.c
@@ -455,10 +455,8 @@ ccowd_rt_disks(int *numdisks)
 		char *namekey = disk_json->u.object.values[j].name;
 		if (strcmp(namekey, "devices") == 0) {
 			json_value *v = disk_json->u.object.values[j].value;
-			for (size_t k = 0; k < v->u.object.length; k++) {
-				char *diskname = v->u.object.values[j].name;
-				nd++;
-			}
+			nd = v->u.object.length;
+			break;
 		}
 	}
 	*numdisks = nd;

--- a/src/ccow/src/libreplicast/replicast.c
+++ b/src/ccow/src/libreplicast/replicast.c
@@ -2306,7 +2306,8 @@ replicast_get_context(struct replicast *robj, enum replicast_opcode opcode,
 static inline void
 free_buf_cb(void *data, int err, int ctx_valid)
 {
-	je_free(data);
+	if (data)
+		je_free(data);
 }
 
 static inline void
@@ -2394,9 +2395,11 @@ replicast_process_recv(struct replicast *robj, const uv_buf_t buf,
 		    (struct repmsg_generic *)&errmsg,
 		    (struct repmsg_generic *)msg, NULL, 0, NULL, free_buf_cb,
 		    buf.base, NULL);
-
+		/*
+		 * The buffer will freed by free_buf_cb() when
+		 * replicast_send() is done
+		 */
 		msgpack_unpack_free(u);
-		je_free(buf.base);
 		return;
 	}
 

--- a/src/ccow/src/libreptrans/reptrans.c
+++ b/src/ccow/src/libreptrans/reptrans.c
@@ -573,9 +573,11 @@ reptrans_ng_recv(enum rt_proto_id id, struct repwqe *wqe, rtbuf_t** rt_out) {
 	uv_buf_t buf;
 	uint512_t hid;
 
-	if (RT_PROTO_ID(msg) != id || RT_PROTO_VER(msg) != reptrans_get_ngproto_version(id))
-		return RT_PROTO_VER(msg);
-
+	if (RT_PROTO_ID(msg) != id || RT_PROTO_VER(msg) != reptrans_get_ngproto_version(id)) {
+		int err = RT_PROTO_VER(msg);
+		if (!err)
+			err = -EIO;
+	}
 	buf.base = repwqe_payload(wqe);
 	buf.len = repwqe_payload_len(wqe);
 	rtbuf_t *rt = rtbuf_init_mapped(&buf, 1);

--- a/src/ccow/src/libreptrans/rtrd/reptrans-rd.h
+++ b/src/ccow/src/libreptrans/rtrd/reptrans-rd.h
@@ -357,6 +357,7 @@ struct repdev_rd {
     int readahead;
     int hdd_readahead;
     int writemap;
+    int env_sync_disable;
     uint64_t bcache_wbc_threshold_mb;
     uint64_t bcache_wbc_flush_mb;
     int direct;

--- a/src/ccow/tools/ecstat.c
+++ b/src/ccow/tools/ecstat.c
@@ -1,26 +1,3 @@
-/*
- * Copyright (c) 2015-2018 Nexenta Systems, inc.
- *
- * This file is part of EdgeFS Project
- * (see https://github.com/Nexenta/edgefs).
- *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
@@ -62,16 +39,19 @@ usage(const char *argv0)
 		"\n"
 		"	-s	Short output\n"
 		"\n"
+		"	-v	Verbose object(s) VM/NHID\n"
+		"\n"
+		"	-T	Server wait timeout, sec (0- disabled, default)\n"
+		"\n"
 		"	-x	eXtended info (valid only with -V)\n"
 		"\n"
 		"	-p	add Parity chunk info (valid only with -x)\n"
 		"\n"
 		"	-l <str> log requested info to server's log file\n"
-		"		<str> can be made of:\n"
+		"		<str> can be made of:"
 		"		- 'L' log lost CHIDs,\n"
 		"		- 'N' log CHIDs if #VBRs = 0\n"
 		"		- 'O' log CHIDs if #VBRs < #Replicas\n"
-		"		- 'P' log CHIDs of leaf manifests that have no parity manifest\n"
 		"\n"
 		"	-j	output in JSON format\n"
 		"\n"
@@ -188,7 +168,307 @@ ecstat_calc_nhid(const char* cid, const char* tid, const char* bid,
 struct vminfo {
 	uint512_t vmchid;
 	uint512_t nhid;
+	char name[2048];
 };
+
+static int
+object_stats_get(ccow_t tc, const char* bid, const char* oid, int flags,
+	int verbose, opp_status_t* ostat) {
+	ccow_completion_t c;
+	int multipart = 0;
+	uint512_t vmchid, nhid;
+	uint64_t size = 0, chunk_size = 0, gen = 0;
+	struct vminfo* vms = NULL;
+	int n_vms = 0;
+
+	int err = ccow_create_completion(tc, NULL, NULL, 1, &c);
+	if (err) {
+		fprintf(stderr, "\nccow_create_completion error: %d\n", err);
+		return err;
+	}
+
+	ccow_lookup_t iter;
+	oid = oid ? oid : "";
+	bid = bid ? bid : "";
+	err = ccow_get(bid, strlen(bid) + 1, oid, strlen(oid) + 1, c, NULL, 0,
+		0, &iter);
+	if (err) {
+		fprintf(stderr, "\nObject information retrieval error: %d\n", err);
+		ccow_release(c);
+		return err;
+	}
+	err = ccow_wait(c, -1);
+	if (err) {
+		return err;
+	}
+	struct ccow_metadata_kv *kv = NULL;
+	while ((kv = ccow_lookup_iter(iter, CCOW_MDTYPE_METADATA | CCOW_MDTYPE_CUSTOM, -1))) {
+		if (strcmp(kv->key, RT_SYSKEY_VM_CONTENT_HASH_ID) == 0) {
+			memcpy(&vmchid, kv->value, sizeof(uint512_t));
+		} else if (strcmp(kv->key, RT_SYSKEY_NAME_HASH_ID) == 0) {
+			memcpy(&nhid, kv->value, sizeof(uint512_t));
+		} else if (strcmp(kv->key, "multipart") == 0) {
+			char* cptr = kv->value;
+			multipart = *cptr == '2';
+		} else if (strcmp(kv->key, RT_SYSKEY_LOGICAL_SIZE) == 0) {
+			ccow_iterator_kvcast(CCOW_KVTYPE_UINT64, kv, &size);
+		} else if (strcmp(kv->key, RT_SYSKEY_CHUNKMAP_CHUNK_SIZE) == 0) {
+			ccow_iterator_kvcast(CCOW_KVTYPE_UINT32, kv, &chunk_size);
+		} else if (strcmp(kv->key, RT_SYSKEY_TX_GENERATION_ID) == 0) {
+			ccow_iterator_kvcast(CCOW_KVTYPE_UINT64, kv, &gen);
+		}
+	}
+	ccow_lookup_release(iter);
+	if (multipart) {
+		/* The multipart object has a JSON string as a content.
+		 * The JSON provides detailed info on parts.
+		 * Collect all the part VMs, calculate their NHIDs
+		 */
+		int iovcnt = size / chunk_size + !!(size % chunk_size);
+		char* iob = je_calloc(1, iovcnt*chunk_size);
+		if (!iob) {
+			fprintf(stderr, "Memory allcoation error");
+			return -ENOMEM;
+		}
+		struct iovec *iov = je_malloc(iovcnt * sizeof(struct iovec));
+		if (!iob) {
+			je_free(iob);
+			fprintf(stderr, "Memory allcoation error");
+			return -ENOMEM;
+		}
+		for (int i = 0; i < iovcnt; i++) {
+			iov[i].iov_len = chunk_size;
+			iov[i].iov_base = iob + i*chunk_size;
+		}
+		err = ccow_create_completion(tc, NULL, NULL, 1, &c);
+		if (err) {
+			je_free(iob);
+			je_free(iov);
+			fprintf(stderr, "ccow_create_completion error: %d\n", err);
+			return -EIO;
+		}
+		err = ccow_get(bid, strlen(bid) + 1, oid, strlen(oid) + 1, c, iov, iovcnt,
+			0, &iter);
+		if (err) {
+			je_free(iob);
+			je_free(iov);
+			ccow_release(c);
+			fprintf(stderr, "ccow_get error: %d\n", err);
+			return -EIO;
+		}
+		err = ccow_wait(c, -1);
+		if (err) {
+			je_free(iob);
+			je_free(iov);
+			fprintf(stderr, "ccow wait error: %d\n", err);
+			return -EIO;
+		}
+		json_value* opts = json_parse(iob, size+1);
+		je_free(iob);
+		je_free(iov);
+		if (!opts) {
+			fprintf(stderr, "Error parsing multipart VM's content");
+			return -EINVAL;
+		}
+		if (opts->type != json_array) {
+			json_value_free(opts);
+			printf("VM's JSON isn't an array: %d\n", opts->type);
+			return -EINVAL;
+		}
+		vms = je_calloc(opts->u.array.length + 1, sizeof(*vms));
+		for (uint32_t i = 0; i < opts->u.array.length; i++) {
+			json_value* item = opts->u.array.values[i];
+			assert(item->type == json_object);
+			struct vminfo* cur = vms + i;
+			char* name = NULL;
+			for (uint32_t j = 0; j < item->u.object.length; j++) {
+				char *namekey = item->u.object.values[j].name;
+				json_value *v = item->u.object.values[j].value;
+				if (strcmp(namekey, "vm_content_hash_id") == 0) {
+					uint512_fromhex(v->u.string.ptr,
+						UINT512_BYTES*2+1, &cur->vmchid);
+				} else if (strcmp(namekey, "name") == 0) {
+					name = v->u.string.ptr;
+					strcpy(cur->name, name);
+					err = ecstat_calc_nhid(tc->cid, tc->tid, bid,
+						name,&cur->nhid);
+					if (err) {
+						json_value_free(opts);
+						je_free(vms);
+						fprintf(stderr, "Error calculating NHID");
+						return err;
+					}
+				}
+			}
+			if (verbose) {
+				char chidstr[UINT512_BYTES*2+1];
+				char nhidstr[UINT512_BYTES*2+1];
+				uint512_dump(&cur->vmchid, chidstr, UINT512_BYTES*2+1);
+				uint512_dump(&cur->nhid, nhidstr, UINT512_BYTES*2+1);
+				printf("Part %d: obj %s, VMCHID %s, NHID %s\n",
+					i+1, name, chidstr, nhidstr);
+			}
+			n_vms++;
+		}
+		json_value_free(opts);
+	}
+	if (!vms) {
+		vms = je_calloc(1, sizeof(*vms));
+		vms[n_vms].vmchid = vmchid;
+		vms[n_vms++].nhid = nhid;
+		if (verbose) {
+			char chidstr[UINT512_BYTES*2+1];
+			uint512_dump(&vmchid, chidstr, UINT512_BYTES*2+1);
+			printf("VMCHID:\t%s\n", chidstr);
+			uint512_dump(&nhid, chidstr, UINT512_BYTES*2+1);
+			printf("NHID:\t%s\n", chidstr);
+			printf("GEN:\t%lu\n", gen);
+		}
+
+	}
+	memset(ostat, 0, sizeof(*ostat));
+	if (multipart) {
+		/* Lookup for VM of each part to make sure they are exist */
+		int cnt = 0, lost = 0;
+		c = NULL;
+		for (int i = 0; i < n_vms; i++) {
+			if (!c) {
+				err = ccow_create_completion(tc, NULL, NULL, PARALLEL_OPS_N, &c);
+				if (err) {
+					je_free(vms);
+					fprintf(stderr, "\nccow_create_completion error: %d\n", err);
+					return err;
+				}
+			}
+			err = ccow_chunk_lookup(c, &vms[i].vmchid, &vms[i].nhid, HASH_TYPE_DEFAULT, RD_ATTR_VERSION_MANIFEST, 1);
+			if (err) {
+				char chidstr[UINT512_STR_BYTES];
+				char nhidstr[UINT512_STR_BYTES];
+				uint512_dump(&vms[i].vmchid, chidstr, UINT512_STR_BYTES);
+				uint512_dump(&vms[i].nhid, nhidstr, UINT512_STR_BYTES);
+				fprintf(stderr, "\nVM lookup init error VMCHID %s NHID %s OBJ %s: %d\n",
+					chidstr, nhidstr, vms[i].name, err);
+				je_free(vms);
+				return err;
+			}
+			cnt++;
+			if ((cnt == PARALLEL_OPS_N) || (i == n_vms - 1)) {
+				err = ccow_wait(c, -1);
+				ccow_drop(c);
+				if (err != 0) {
+					ostat->n_cm_tl_lost++;
+					ostat->n_cm_tl++;
+					lost++;
+				}
+				ccow_release(c);
+				c = NULL;
+				cnt = 0;
+			}
+		}
+		if (lost) {
+			je_free(vms);
+			return -EIO;
+		}
+	}
+
+	int vdev_usage_count = 0;
+	uint64_t vdev_usage_summ = 0;
+	opp_status_t* req_stat = je_calloc(PARALLEL_OPS_N, sizeof(opp_status_t));
+	if (!req_stat) {
+		fprintf(stderr, "Memory allocation error");
+		return -ENOMEM;
+	}
+
+	int cnt = 0;
+	err = ccow_create_completion(tc, NULL, NULL, PARALLEL_OPS_N, &c);
+	if (err) {
+		fprintf(stderr, "\nccow_create_completion error: %d\n", err);
+		je_free(req_stat);
+		je_free(vms);
+		return err;
+	}
+	for (int i = 0; i < n_vms; i++) {
+		err = ccow_opp_satus_request(tc, &vms[i].vmchid, &vms[i].nhid, c,
+			flags, req_stat + cnt);
+		if (err) {
+			fprintf(stderr, "\nError getting parity protection status: %d\n",
+				err);
+			je_free(req_stat);
+			je_free(vms);
+			return err;
+		}
+		cnt++;
+		if ((cnt == PARALLEL_OPS_N) || (i == n_vms - 1)) {
+			err = ccow_timed_wait(c, -1, 10000);
+			ccow_drop(c);
+			if (err) {
+				if (verbose) {
+					char chidstr[UINT512_BYTES*2+1];
+					char nhidstr[UINT512_BYTES*2+1];
+					uint512_dump(&vms[i].vmchid, chidstr, UINT512_BYTES*2+1);
+					uint512_dump(&vms[i].nhid, nhidstr, UINT512_BYTES*2+1);
+					if (err != -EBUSY)
+						fprintf(stderr, "\nPart %d corrupted, VMCHID %s, NHID %s, name %s\n",
+							i+1, chidstr, nhidstr, vms[i].name);
+					else
+						fprintf(stderr, "\nPart %d corrupted or timeout has expired, VMCHID %s, NHID %s, name %s\n",
+							i+1, chidstr, nhidstr, vms[i].name);
+				}
+				ostat->n_cm_tl++;
+				ostat->n_cm_tl_lost++;
+			} else {
+				for (int j = 0; j < cnt; j++) {
+					ostat->n_cm_tl += req_stat[j].n_cm_tl;
+					ostat->n_cm_zl += req_stat[j].n_cm_zl;
+					ostat->n_cp += req_stat[j].n_cp;
+					ostat->n_cpar += req_stat[j].n_cpar;
+					ostat->n_cm_zl_verified += req_stat[j].n_cm_zl_verified;
+					ostat->n_cm_tl_verified += req_stat[j].n_cm_tl_verified;
+					ostat->n_cp_verified += req_stat[j].n_cp_verified;
+					ostat->n_cpar_verified += req_stat[j].n_cpar_verified;
+					ostat->n_cm_zl_1vbr += req_stat[j].n_cm_zl_1vbr;
+					ostat->n_cm_tl_1vbr += req_stat[j].n_cm_tl_1vbr;
+					ostat->n_cp_1vbr += req_stat[j].n_cp_1vbr;
+					ostat->n_cm_zl_lost += req_stat[j].n_cm_zl_lost;
+					ostat->n_cm_tl_lost += req_stat[j].n_cm_tl_lost;
+					ostat->n_cp_lost += req_stat[j].n_cp_lost;
+					ostat->n_cpar_lost += req_stat[j].n_cpar_lost;
+					ostat->n_cm_zl_pp += req_stat[j].n_cm_zl_pp;
+					ostat->n_cm_zl_erc_err += req_stat[j].n_cm_zl_erc_err;
+					ostat->n_cm_tl_erc_err += req_stat[j].n_cm_tl_erc_err;
+					if (ostat->n_cm_zl_pp && !ostat->pp_data_number) {
+						ostat->pp_algo = req_stat[j].pp_algo;
+						ostat->pp_data_number = req_stat[j].pp_data_number;
+						ostat->pp_parity_number = req_stat[j].pp_parity_number;
+						ostat->pp_domain = req_stat[j].pp_domain;
+					}
+					ostat->hostid = req_stat[j].hostid;
+					err = vdev_usage_avg_update(&req_stat[j].hostid,
+						req_stat[j].vdevs_usage,
+						req_stat[j].n_vdevs);
+					je_free(req_stat[j].vdevs_usage);
+					if (err) {
+						je_free(vms);
+						je_free(req_stat);
+						return err;
+					}
+				}
+			}
+			cnt = 0;
+			memset(req_stat, 0, sizeof(opp_status_t)*PARALLEL_OPS_N);
+			if (i != n_vms - 1) {
+				err = ccow_create_completion(tc, NULL, NULL, PARALLEL_OPS_N, &c);
+				if (err) {
+					fprintf(stderr, "\nccow_create_completion error: %d\n", err);
+					je_free(req_stat);
+					return err;
+				}
+			}
+		}
+	}
+	je_free(req_stat);
+	return 0;
+}
 
 int
 main(int argc, char** argv) {
@@ -212,8 +492,11 @@ main(int argc, char** argv) {
 	uint32_t chunk_size = 0;
 	uint64_t gen = 0;
 	int verbose = 0;
+	int batch = 0;
+	char* log_file = NULL;
+	time_t firstTS = 0;
 
-	while ((opt = getopt(argc, argv, "ho:b:c:t:sVxpl:jv")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:b:c:t:sVxpl:jvBL:T:")) != -1) {
 		switch(opt) {
 
 			case 'o':
@@ -260,6 +543,27 @@ main(int argc, char** argv) {
 				verbose = 1;
 				break;
 
+			case 'B':
+				batch = 1;
+				break;
+
+			case 'L':
+				log_file = strdup(optarg);
+				break;
+
+			case 'T':
+			{
+				struct tm ltm;
+				char* p = strptime(optarg, "%m-%d-%Y %H:%M:%S", &ltm);
+				if (!p) {
+					fprintf(stderr, "The time stamp format is MM-DD-YYYY H:M:S");
+					return -1;
+
+				}
+				firstTS = mktime(&ltm);
+				break;
+			}
+
 			case 'h':
 			default:
 				usage(argv[0]);
@@ -267,8 +571,6 @@ main(int argc, char** argv) {
 		}
 	}
 
-	if (!oid)
-		oid = "";
 	if (!tid)
 		tid = strdup(TID_DEFAULT);
 	if (!cid)
@@ -280,6 +582,7 @@ main(int argc, char** argv) {
 	ccow_t cl;
 	char path[PATH_MAX];
 	snprintf(path, sizeof(path), "%s/etc/ccow/ccow.json", nedge_path());
+
 	int ccow_fd = open(path, O_RDONLY);
 	if (ccow_fd < 0) {
 		fprintf(stderr, "ccow.json open error %d: %s\n",
@@ -303,147 +606,6 @@ main(int argc, char** argv) {
 		fprintf(stderr, "\nccow init error: cluster or tenant ID is wrong\n");
 		return -EINVAL;
 	}
-	ccow_completion_t c;
-	err = ccow_create_completion(cl, NULL, NULL, 1, &c);
-	if (err) {
-		fprintf(stderr, "\nccow_create_completion error: %d\n", err);
-		ccow_tenant_term(cl);
-		return err;
-	}
-
-	ccow_lookup_t iter;
-	err = ccow_get(bid, strlen(bid) + 1, oid, strlen(oid) + 1, c, NULL, 0,
-		0, &iter);
-	if (err) {
-		fprintf(stderr, "\nObject information retrieval error: %d\n", err);
-		ccow_release(c);
-		ccow_tenant_term(cl);
-		return err;
-	}
-	err = ccow_wait(c, -1);
-	if (err) {
-		fprintf(stderr, "\nCan't get object info: bucket or object ID is"
-			" wrong\n");
-		ccow_tenant_term(cl);
-		return -EINVAL;
-	}
-	struct ccow_metadata_kv *kv = NULL;
-	while ((kv = ccow_lookup_iter(iter, CCOW_MDTYPE_METADATA | CCOW_MDTYPE_CUSTOM, -1))) {
-		if (strcmp(kv->key, RT_SYSKEY_VM_CONTENT_HASH_ID) == 0) {
-			memcpy(&vmchid, kv->value, sizeof(uint512_t));
-		} else if (strcmp(kv->key, RT_SYSKEY_NAME_HASH_ID) == 0) {
-			memcpy(&nhid, kv->value, sizeof(uint512_t));
-		} else if (strcmp(kv->key, "multipart") == 0) {
-			char* cptr = kv->value;
-			multipart = *cptr == '2';
-		} else if (strcmp(kv->key, RT_SYSKEY_LOGICAL_SIZE) == 0) {
-			ccow_iterator_kvcast(CCOW_KVTYPE_UINT64, kv, &size);
-		} else if (strcmp(kv->key, RT_SYSKEY_CHUNKMAP_CHUNK_SIZE) == 0) {
-			ccow_iterator_kvcast(CCOW_KVTYPE_UINT32, kv, &chunk_size);
-		} else if (strcmp(kv->key, RT_SYSKEY_TX_GENERATION_ID) == 0) {
-			ccow_iterator_kvcast(CCOW_KVTYPE_UINT64, kv, &gen);
-		}
-	}
-	ccow_lookup_release(iter);
-	if (multipart) {
-		/* The multipart object has a JSON string as a content.
-		 * The JSON provides detailed info on parts.
-		 * Collect all the part VMs, calculate their NHIDs
-		 */
-		int iovcnt = size / chunk_size + !!(size % chunk_size);
-		char* iob = je_calloc(1, iovcnt*chunk_size);
-		if (!iob) {
-			ccow_tenant_term(cl);
-			fprintf(stderr, "Memory allcoation error");
-			return -ENOMEM;
-		}
-		struct iovec *iov = je_malloc(iovcnt * sizeof(struct iovec));
-		if (!iob) {
-			je_free(iob);
-			ccow_tenant_term(cl);
-			fprintf(stderr, "Memory allcoation error");
-			return -ENOMEM;
-		}
-		for (int i = 0; i < iovcnt; i++) {
-			iov[i].iov_len = chunk_size;
-			iov[i].iov_base = iob + i*chunk_size;
-		}
-		err = ccow_create_completion(cl, NULL, NULL, 1, &c);
-		if (err) {
-			je_free(iob);
-			je_free(iov);
-			ccow_tenant_term(cl);
-			fprintf(stderr, "ccow_create_completion error: %d\n", err);
-			return -EIO;
-		}
-		err = ccow_get(bid, strlen(bid) + 1, oid, strlen(oid) + 1, c, iov, iovcnt,
-			0, &iter);
-		if (err) {
-			je_free(iob);
-			je_free(iov);
-			ccow_release(c);
-			fprintf(stderr, "ccow_get error: %d\n", err);
-			return -EIO;
-		}
-		err = ccow_wait(c, -1);
-		if (err) {
-			je_free(iob);
-			je_free(iov);
-			fprintf(stderr, "ccow wait error: %d\n", err);
-			return -EIO;
-		}
-		json_value* opts = json_parse(iob, size+1);
-		je_free(iob);
-		je_free(iov);
-		if (!opts) {
-			fprintf(stderr, "Error parsing multipart VM's content");
-			return -EINVAL;
-		}
-		if (opts->type != json_array) {
-			json_value_free(opts);
-			printf("VM's JSON isn't an array: %d\n", opts->type);
-			return -EINVAL;
-		}
-		vms = je_calloc(opts->u.array.length + 1, sizeof(*vms));
-		for (uint32_t i = 0; i < opts->u.array.length; i++) {
-			json_value* item = opts->u.array.values[i];
-			assert(item->type == json_object);
-			struct vminfo* cur = vms + i;
-			for (uint32_t j = 0; j < item->u.object.length; j++) {
-				char *namekey = item->u.object.values[j].name;
-				json_value *v = item->u.object.values[j].value;
-				if (strcmp(namekey, "vm_content_hash_id") == 0) {
-					uint512_fromhex(v->u.string.ptr,
-						UINT512_BYTES*2+1, &cur->vmchid);
-				} else if (strcmp(namekey, "name") == 0) {
-					err = ecstat_calc_nhid(cid, tid, bid,
-						v->u.string.ptr,&cur->nhid);
-					if (err) {
-						json_value_free(opts);
-						je_free(vms);
-						fprintf(stderr, "Error calculating NHID");
-						return err;
-					}
-				}
-			}
-			n_vms++;
-		}
-		json_value_free(opts);
-	}
-	if (!vms) {
-		vms = je_calloc(1, sizeof(*vms));
-		vms[n_vms].vmchid = vmchid;
-		vms[n_vms++].nhid = nhid;
-		if (verbose) {
-			char chidstr[UINT512_BYTES*2+1];
-			uint512_dump(&vmchid, chidstr, UINT512_BYTES*2+1);
-			printf("VMCHID:\t%s\n", chidstr);
-			uint512_dump(&nhid, chidstr, UINT512_BYTES*2+1);
-			printf("NHID:\t%s\n", chidstr);
-			printf("GEN:\t%lu\n", gen);
-		}
-
-	}
 	opp_status_t ostat = {.n_cp = 0};
 	int flags = 0; /* EC-information only */
 	if (verify)
@@ -459,94 +621,175 @@ main(int argc, char** argv) {
 			flags |= OPP_STATUS_FLAG_LACKVBR;
 		if (strchr(lerr, 'O'))
 			flags |= OPP_STATUS_FLAG_MISSVBR;
-		if (strchr(lerr, 'P'))
-			flags |= OPP_STATUS_FLAG_NOPM;
 	}
-	int vdev_usage_count = 0;
-	uint64_t vdev_usage_summ = 0;
-	opp_status_t* req_stat = je_calloc(PARALLEL_OPS_N, sizeof(opp_status_t));
-	if (!req_stat) {
-		fprintf(stderr, "Memory allocation error");
-		ccow_tenant_term(cl);
-		return err;
-	}
-	int cnt = 0;
-	err = ccow_create_completion(cl, NULL, NULL, PARALLEL_OPS_N, &c);
-	if (err) {
-		fprintf(stderr, "\nccow_create_completion error: %d\n", err);
-		ccow_tenant_term(cl);
-		je_free(req_stat);
-		return err;
-	}
-	for (int i = 0; i < n_vms; i++) {
-		err = ccow_opp_satus_request(cl, &vms[i].vmchid, &vms[i].nhid, c,
-			flags, req_stat + cnt);
-		if (err) {
-			fprintf(stderr, "\nError getting parity protection status: %d\n",
-				err);
-			ccow_tenant_term(cl);
-			je_free(req_stat);
-			return err;
+
+	if (batch) {
+		/* Iterate bucket and check each object */
+		char last_obj[PATH_MAX] = {0};
+		ccow_lookup_t iter = NULL;
+		struct iovec iov;
+		iov.iov_base = last_obj;
+		iov.iov_len = strlen(last_obj) + 1;
+		ccow_completion_t c1;
+		int ci = 0, total = 0;
+		FILE* f = NULL;
+		if (log_file) {
+			f = fopen(log_file, "w");
+			if (!f) {
+				fprintf(stderr, "ERROR: Couldn't open log file %s for writing\n", log_file);
+				return -1;
+			}
 		}
-		cnt++;
-		if ((cnt == PARALLEL_OPS_N) || (i == n_vms - 1)) {
-			err = ccow_wait(c, -1);
+
+		while (1) {
+			err = ccow_create_completion(cl, NULL, NULL, 1, &c1);
 			if (err) {
-				fprintf(stderr, "\nIO error: %d\n", err);
-				ccow_tenant_term(cl);
-				je_free(req_stat);
-				return err;
+				log_error(lg, "Bucket clone: completion create error %d", err);
+				goto _release;
 			}
-			for (int j = 0; j < cnt; j++) {
-				ostat.n_cm_tl += req_stat[j].n_cm_tl;
-				ostat.n_cm_zl += req_stat[j].n_cm_zl;
-				ostat.n_cp += req_stat[j].n_cp;
-				ostat.n_cpar += req_stat[j].n_cpar;
-				ostat.n_cm_zl_verified += req_stat[j].n_cm_zl_verified;
-				ostat.n_cm_tl_verified += req_stat[j].n_cm_tl_verified;
-				ostat.n_cp_verified += req_stat[j].n_cp_verified;
-				ostat.n_cpar_verified += req_stat[j].n_cpar_verified;
-				ostat.n_cm_zl_1vbr += req_stat[j].n_cm_zl_1vbr;
-				ostat.n_cm_tl_1vbr += req_stat[j].n_cm_tl_1vbr;
-				ostat.n_cp_1vbr += req_stat[j].n_cp_1vbr;
-				ostat.n_cm_zl_lost += req_stat[j].n_cm_zl_lost;
-				ostat.n_cm_tl_lost += req_stat[j].n_cm_tl_lost;
-				ostat.n_cp_lost += req_stat[j].n_cp_lost;
-				ostat.n_cpar_lost += req_stat[j].n_cpar_lost;
-				ostat.n_cm_zl_pp += req_stat[j].n_cm_zl_pp;
-				ostat.n_cm_zl_erc_err += req_stat[j].n_cm_zl_erc_err;
-				ostat.n_cm_tl_erc_err += req_stat[j].n_cm_tl_erc_err;
-				if (ostat.n_cm_zl_pp && !ostat.pp_data_number) {
-					ostat.pp_algo = req_stat[j].pp_algo;
-					ostat.pp_data_number = req_stat[j].pp_data_number;
-					ostat.pp_parity_number = req_stat[j].pp_parity_number;
-					ostat.pp_domain = req_stat[j].pp_domain;
+			iov.iov_len = strlen(last_obj) + 1;
+			iov.iov_base = last_obj;
+			err = ccow_tenant_get(cl->cid, cl->cid_size, cl->tid,
+				cl->tid_size, bid, strlen(bid) + 1, "", 1, c1, &iov, 1,
+				1000, CCOW_GET_LIST, &iter);
+			if (err) {
+				log_error(lg, "Source bucket list error %s/%s/%s: %d",
+					cl->cid, cl->tid, bid, err);
+				goto _release;
+			}
+
+			err = ccow_wait(c1, 0);
+			if (err) {
+				log_error(lg, "Source bucket list error (wait) %s/%s/%s: %d",
+					cl->cid, cl->tid, bid, err);
+				goto _release;
+			}
+			total  += ccow_lookup_length(iter, CCOW_MDTYPE_NAME_INDEX);
+			struct ccow_metadata_kv *kv = NULL;
+			int idx = 0, processed = 0;
+			while ((kv = ccow_lookup_iter(iter, CCOW_MDTYPE_NAME_INDEX, idx++)) != NULL) {
+				/* Skip the last entry from previous iteration */
+				if (!strcmp(kv->key, last_obj)) {
+					total--;
+					continue;
 				}
-				ostat.hostid = req_stat[j].hostid;
-				err = vdev_usage_avg_update(&req_stat[j].hostid,
-					req_stat[j].vdevs_usage,
-					req_stat[j].n_vdevs);
-				je_free(req_stat[j].vdevs_usage);
+				/* Skip multipart */
+				if (strstr(kv->key, "\xEF\xBF\xBF{") == kv->key) {
+					total--;
+					continue;
+				}
+				strcpy(last_obj, kv->key);
+
+				msgpack_u u;
+				msgpack_unpack_init_b(&u, kv->value, kv->value_size, 0);
+				uint8_t ver = 0, deleted = 0;
+				uint64_t ts = 0, gen = 0;
+				uint512_t vmchid;
+				err = msgpack_unpack_uint8(&u, &ver);
 				if (err) {
-					ccow_tenant_term(cl);
-					je_free(req_stat);
-					return err;
+					log_error(lg, "Bucket entry unpack error %d", err);
+					goto _release;
 				}
-			}
-			cnt = 0;
-			memset(req_stat, 0, sizeof(opp_status_t)*PARALLEL_OPS_N);
-			if (i != n_vms - 1) {
-				err = ccow_create_completion(cl, NULL, NULL, PARALLEL_OPS_N, &c);
+
+				err = msgpack_unpack_uint8(&u, &deleted);
 				if (err) {
-					fprintf(stderr, "\nccow_create_completion error: %d\n", err);
-					ccow_tenant_term(cl);
-					je_free(req_stat);
-					return err;
+					log_error(lg, "Bucket entry unpack error %d", err);
+					goto _release;
+				}
+
+				err = msgpack_unpack_uint64(&u, &ts);
+				if (err) {
+					log_error(lg, "Bucket entry unpack error %d", err);
+					goto _release;
+				}
+
+				err = msgpack_unpack_uint64(&u, &gen);
+				if (err) {
+					log_error(lg, "Bucket entry unpack error %d", err);
+					goto _release;
+				}
+
+				err = replicast_unpack_uint512(&u, &vmchid);
+				if (err) {
+					log_error(lg, "Bucket entry unpack error %d", err);
+					goto _release;
+				}
+
+				if (firstTS && ((uint64_t)firstTS > ts/1000000)) {
+					total--;
+					continue;
+				}
+				processed++;
+				err = object_stats_get(cl, bid, last_obj, flags, verbose, &ostat);
+				if (err) {
+					if (err == -ENOENT) {
+						time_t t = ts/1000000;
+						struct tm tm;
+						gmtime_r(&t, &tm);
+						char buf[1024];
+						size_t n = strftime(buf, sizeof(buf), "%m-%d-%Y %H:%M:%S", &tm);
+						if (f) {
+							fprintf(f, "%s/%s/%s/%s;%s;;;;LOST;\n", cl->cid,
+								cl->tid, bid, last_obj, buf);
+						}
+						printf("ERROR: object not found %s/%s/%s/%s, date %s\n",
+							cl->cid, cl->tid, bid, last_obj, buf);
+					} else {
+						fprintf(stderr, "%s/%s/%s/%s object stat error %d\n",
+							cl->cid, cl->tid, bid, last_obj, err);
+					}
+					continue;
+				}
+
+				size_t total_chunks = ostat.n_cp + ostat.n_cm_zl + ostat.n_cm_tl;
+				size_t total_1vbr = ostat.n_cp_1vbr + ostat.n_cm_zl_1vbr + ostat.n_cm_tl_1vbr;
+				size_t lost = ostat.n_cp_lost + ostat.n_cm_tl_lost + ostat.n_cm_zl_lost;
+				if (lost) {
+					time_t t = ts/1000000;
+					struct tm tm;
+					gmtime_r(&t, &tm);
+					char buf[1024];
+					size_t n = strftime(buf, sizeof(buf), "%m-%d-%Y %H:%M:%S", &tm);
+					if (f) {
+						fprintf(f, "%s/%s/%s/%s;%s;%lu;%lu;%lu;DATALOSS;\n", cl->cid,
+							cl->tid, bid, last_obj, buf, lost, total_chunks, total_1vbr);
+					}
+					printf("ERROR: object %s, date %s, #chunks %lu, #lost %lu, #1vbr %lu\n",
+						last_obj, buf, total_chunks, lost, total_1vbr);
+				} else if (total_chunks != total_1vbr) {
+					printf("ostat.n_cp_1vbr %lu, ostat.n_cm_zl_1vbr %lu, ostat.n_cm_tl_1vbr %lu\n", ostat.n_cp_1vbr, ostat.n_cm_zl_1vbr, ostat.n_cm_tl_1vbr);
+					printf("WARN: Can be lost object %s, #chunks %lu, #lost %lu, #1vbr %lu\n",
+						last_obj, total_chunks, lost, total_1vbr);
+				} else {
+					printf("%d/%d\r", ++ci, total);
 				}
 			}
+			ccow_lookup_release(iter);
+			iter = NULL;
+			if (!processed)
+				break;
 		}
+_release:
+		ccow_release(c1);
+		if (iter)
+			ccow_lookup_release(iter);
+		if (f)
+			fclose(f);
+		printf("\n");
+		return 0;
 	}
-	je_free(req_stat);
+
+
+
+	err = object_stats_get(cl, bid, oid, flags, verbose, &ostat);
+	if (err) {
+		if (err == -ENOENT)
+			fprintf(stderr, "Object not found\n");
+		else
+			fprintf(stderr, "Error %d\n", err);
+		return err;
+	}
+
 	double ep = ostat.n_cm_zl ? (ostat.n_cm_zl_pp*100.0f/ostat.n_cm_zl) : 0.0f;
 	size_t total_chunks = ostat.n_cp + ostat.n_cm_zl + ostat.n_cm_tl;
 	size_t total_verified = ostat.n_cp_verified + ostat.n_cm_zl_verified + ostat.n_cm_tl_verified;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
1. The ecstat tool got a quick bucket validation option.
Usage: `ecstat -V -x -c <cl> -t <tn> -b <bk> -B [-L <filename>] [-T <date>]`
Where:
 `-B` enable bucket objects validation mode
`-L` store list of corrupted objects in a CSV file
`-T` consider only objects which are older than the specified date. Date format is MM-DD-YYYY H:M:S (UTC).

2. Several fixes for network error handling
3. RTRD fix synchronous data types. Some temporary metadata types are synced to disk after each LMDB txn commit for better fault tolerance. Enabled only if a value of the `sync` option in the rt-rd.json is greater or equal to 1.
4. RTRD WAL flush fix: make sure all the entries are removed from the log after the WAL flush.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #407

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
