### PR TITLE
Issue-425: added vdevstore locking to flexhash_fhserver_vdevs()

### DIFF
--- a/src/ccow/src/libflexhash/flexhash.c
+++ b/src/ccow/src/libflexhash/flexhash.c
@@ -3688,8 +3688,10 @@ flexhash_fhserver_vdevs(volatile struct flexhash *fhtable, struct fhserver *fhse
 		*vdevcount = 0;
 		return NULL;
 	}
+	pthread_mutex_lock(&fhtable->vdevstore->mutex);
 	struct fhdev *fhdev = fhserver->vdevlist.devlist;
 	if ((!fhdev) && (fhserver->nr_vdevs <= 0)) {
+		pthread_mutex_unlock(&fhtable->vdevstore->mutex);
 		*vdevcount = 0;
 		je_free(retvdev);
 		return NULL;
@@ -3718,7 +3720,7 @@ flexhash_fhserver_vdevs(volatile struct flexhash *fhtable, struct fhserver *fhse
 		fhdev = fhdev->next;
 		i++;
 	}
-
+	pthread_mutex_unlock(&fhtable->vdevstore->mutex);
 	*vdevcount = i;
 	return retvdev;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
Added some locking to FH

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #425

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
