### PR TITLE
Use "-s" flag to grpc-nfs when starting nfs through edgefs-start.sh.

### DIFF
--- a/scripts/edgefs-start.sh
+++ b/scripts/edgefs-start.sh
@@ -368,7 +368,7 @@ case $1 in
 		start_msg "ganesha"
 		debug_wait "ganesha"
 		export CCOW_SVCTYPE="nfs"
-		exec grpc-nfs $CCOW_SVCNAME $1 $2 $3 $4 $5 $6 $7 $8 $9
+		exec grpc-nfs -s $CCOW_SVCNAME $1 $2 $3 $4 $5 $6 $7 $8 $9
                 ;;
         "s3x")
                 shift


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [* ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
Added "-s" option back to edgefs-start.sh

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
