### PR TITLE
Unnamed Get performance fix

### DIFF
--- a/src/ccow/src/libccow/ccow-impl.h
+++ b/src/ccow/src/libccow/ccow-impl.h
@@ -1187,6 +1187,7 @@ struct getcommon_client_req {
 	uv_buf_t payload[REPLICAST_DGRAM_MAX];
 	uv_buf_t one_payload;
 	uint256_t dgram_idx;
+	uint64_t dgrams;
 	int nbufs;
 	rtbuf_t *rb;
 	int rb_cached;
@@ -1226,6 +1227,8 @@ struct getcommon_client_req {
 	struct sockaddr_in6 selected_ngaddr;
 	int rtselected;
 	int rttransferred;
+	int rt_begin_ts;
+	int rt_last_ts;
 	int rt_inprogress;
 	uint64_t content_length;
 	int error;

--- a/src/ccow/src/libccow/getcommon_client.c
+++ b/src/ccow/src/libccow/getcommon_client.c
@@ -94,6 +94,7 @@ client_getcommon_init(struct state *st)
 	}
 	r->delayed_start_timer_req->data = NULL;
 	r->delayed_start_fd = uv_hpt_timer_init(tc->loop, r->delayed_start_timer_req);
+	r->dgrams = 0;
 }
 
 static void
@@ -370,7 +371,13 @@ client_getcommon_sendaccept_timeout(uv_timer_t *treq, int status)
 		r->timer_req->data = NULL;
 	}
 
-	tc->get_retry_cnt++;
+	int n_frames = uint256_hweight(&r->dgram_idx);
+	uint64_t dur_avg = r->rt_last_ts - r->rt_begin_ts;
+	if (n_frames)
+		dur_avg /= n_frames;
+	log_warn(lg, "RT timeout: received %d out of %lu frames, "
+		"frame_delta_avg %lu uS, get_retry_cnt %lu",
+		n_frames, r->dgrams, dur_avg, tc->get_retry_cnt);
 
 	state_event(st, EV_TIMEOUT);
 }
@@ -1117,6 +1124,9 @@ client_getcommon_reset(struct getcommon_client_req *r)
 	}
 	if (!uint256_cmp(&r->dgram_idx, &uint256_null))
 		repctx_wqe_reset(ctx);
+	r->dgrams = 0;
+	r->rt_begin_ts = 0;
+	r->rt_last_ts = 0;
 	return 0;
 }
 
@@ -1146,6 +1156,13 @@ client_getcommon_rttransfer(struct state *st)
 		log_debug(lg, "RT is all transfered. Retransmit case drop");
 		return;
 	}
+	if (!req->rt_begin_ts)
+		req->rt_begin_ts = get_timestamp_us();
+	req->rt_last_ts = get_timestamp_us();
+	if (req->timer_req->data) {
+		uv_timer_stop(req->timer_req);
+		req->timer_req->data = NULL;
+	}
 
 	int idx = wqe->msg->hdr.datagram_num - 1;
 	if (idx >= wqe->msg->num_datagrams) {
@@ -1160,6 +1177,7 @@ client_getcommon_rttransfer(struct state *st)
 
 	// now update the mask for the ones we have received
 	uint256_bset(&req->dgram_idx, idx);
+	req->dgrams = wqe->msg->num_datagrams;
 
 	if (unlikely(lg->level <= LOG_LEVEL_DUMP)) {
 		/* place this datagram into receiving buffer */
@@ -1186,6 +1204,9 @@ client_getcommon_rttransfer(struct state *st)
 
 	if (uint256_hweight(&req->dgram_idx) < msg->num_datagrams) {
 		/* wait for more datagrams */
+		req->timer_req->data = st;
+		uv_timer_start(req->timer_req, client_getcommon_sendaccept_timeout,
+			2, 0);
 		return;
 	}
 
@@ -1194,10 +1215,6 @@ client_getcommon_rttransfer(struct state *st)
 	    msg->num_datagrams, ctx->sequence_cnt, ctx->sub_sequence_cnt);
 	req->nbufs = msg->num_datagrams;
 
-	if (req->timer_req->data) {
-		uv_timer_stop(req->timer_req);
-		req->timer_req->data = NULL;
-	}
 
 	req->rttransferred = 1;
 	if (req->reqtype == GET_REQ_TYPE_NAMED_RT) {

--- a/src/ccow/src/libreptrans/payload-s3.h
+++ b/src/ccow/src/libreptrans/payload-s3.h
@@ -29,6 +29,8 @@
 
 #define EDGE_USER_AGENT "EdgeRTRD/1.0"
 
+struct get_cache;
+
 struct payload_s3 {
 	int ssl_en;
 	char host[1024];
@@ -44,9 +46,12 @@ struct payload_s3 {
 	pthread_cond_t get_cond;
 	uint64_t parallel_gets;
 	uint64_t parallel_gets_max;
+	struct get_cache* cache;
 };
 
-int payload_s3_init(char *url, char *region, char *keyfile, struct payload_s3 **ctx_out);
+int
+payload_s3_init(char *url, char *region, char *keyfile, uint64_t cache_entries_max,
+	struct payload_s3 **ctx_out);
 void payload_s3_destroy(struct payload_s3 *ctx);
 int payload_s3_put(struct payload_s3 *ctx, const char* key, uv_buf_t *data);
 int payload_s3_put_multi(struct payload_s3 *ctx, uv_buf_t* keys, uv_buf_t* data, size_t n);

--- a/src/ccow/tools/s3_payload_bench.c
+++ b/src/ccow/tools/s3_payload_bench.c
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
 		exit(1);
 	}
 
-	int err = payload_s3_init(url, region, key_file, &ctx);
+	int err = payload_s3_init(url, region, key_file, is_embedded() ? 20 : 400, &ctx);
 	if (err) {
 		fprintf(stderr, "Coudln't initialize S3 payload context: %d.\n", err);
 		exit(1);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
The following changed were made to Unnamed Get data path in order to get better performance when payloads are on external S3 service:
1. Precisely track the rendezvous transfer timeout. Every time the new RT frame received, restart the timeout timer for a small interval which should be enough for the reception the next frame in the RT.
2. Implemented the S3 get cache which prevents a duplicate S3 fetch if the previous GET RT failed.   

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
