### PR TITLE
S3 offload utilization separated from disk utilization

### DIFF
--- a/src/ccow/src/libreptrans/reptrans-device.h
+++ b/src/ccow/src/libreptrans/reptrans-device.h
@@ -229,6 +229,8 @@ struct reptrans_devinfo_req {
 
 	uint64_t ttag_entries[TT_LAST];
 	uint64_t ttag_size[TT_LAST];
+	uint64_t s3_offload_capacity; /* Only set if S3 payloads offload is enabled */
+	uint64_t s3_offload_used;
 
 	struct reptrans_gw_stats gw_stats_get_lat;
 	struct reptrans_gw_stats gw_stats_put_lat;

--- a/src/ccow/src/libreptrans/reptrans.c
+++ b/src/ccow/src/libreptrans/reptrans.c
@@ -1306,6 +1306,11 @@ push_stats(struct repdev *dev)
 	auditc_low_objid(gauge, "reptrans.incoming_batches_queued", &dev->vdevid,
 			stat->ttag_entries[TT_BATCH_INCOMING_QUEUE]);
 
+	auditc_low_objid(gauge, "reptrans.s3_offload_size", &dev->vdevid,
+			stat->s3_offload_capacity);
+	auditc_low_objid(gauge, "reptrans.s3_offload_used", &dev->vdevid,
+			stat->s3_offload_used);
+
 	ccowd_fhready_lock(FH_LOCK_READ);
 	auditc_low_rowusage(gauge, "reptrans.rowusagecounters", &dev->vdevid,
 		ccow_daemon->flexhash->numrows, ccow_daemon->flexhash);

--- a/src/efscli/system/status.go
+++ b/src/efscli/system/status.go
@@ -37,6 +37,7 @@ import (
 	"fmt"
 	"time"
 	"github.com/Nexenta/edgefs/src/efscli/efsutil"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/im-kulikov/sizefmt"
 	"encoding/json"
@@ -102,12 +103,14 @@ func SystemStatus(isSummary bool) error {
 	sdmap := make(map[string]map[string]string)
 	vdmap := make(map[string]map[string]string)
 	smap := make(map[string]map[string]map[string]string)
+	fromCP := false
 	// Try to init servermap from checkpoint
 	cp_buf, err := ioutil.ReadFile(os.Getenv("NEDGE_HOME") + "/var/run/flexhash-checkpoint.json")
 	if err == nil {
 		var cp interface{}
 		err = json.Unmarshal(cp_buf, &cp)
 		if err == nil {
+			fromCP = true
 			cp_kv := cp.(map[string]interface{})
 			// Loading VDEVs
 			if vdev_if, ok := cp_kv["vdevlist"]; ok {
@@ -150,6 +153,10 @@ func SystemStatus(isSummary bool) error {
 		pattern := regexp.MustCompile(`^gauges\.ccow\.clengine\.server\.(?P<sid>\w+).(?P<ipaddr>\w+).(?P<vdevid>\w+)\|(?P<state>\d+\.\d+)\|(?P<ts>\d+)`)
 		if m := pattern.FindAllStringSubmatch(line, -1); m != nil {
 			sid := m[0][1]
+			if _, ok := sdmap[sid]; fromCP && !ok {
+				// Skip unknown servers (possibly after re-checkpointing)
+				continue
+			}
 			vdevid := m[0][3]
 			st := m[0][4]
 			ts, err := strconv.Atoi(m[0][5])
@@ -202,6 +209,10 @@ func SystemStatus(isSummary bool) error {
 			key := m[0][1]
 			sid := m[0][2]
 			val := m[0][4]
+			if _, ok := sdmap[sid]; fromCP && !ok {
+				// Skip unknown servers (possibly after re-checkpointing)
+				continue
+			}
 			ts, err := strconv.Atoi(m[0][5])
 			if err != nil {
 				return err
@@ -226,6 +237,10 @@ func SystemStatus(isSummary bool) error {
 			key := m[0][1]
 			sid := m[0][2]
 			strval := m[0][4]
+			if _, ok := sdmap[sid]; fromCP && !ok {
+				// Skip unknown servers (possibly after re-checkpointing)
+				continue
+			}
 			ts, err := strconv.Atoi(m[0][6])
 			if err != nil {
 				return err
@@ -322,87 +337,162 @@ func SystemStatus(isSummary bool) error {
 		}
 	}
 
-	if isSummary {
-		totalCapacity := int64(0)
-		totalUsed := int64(0)
-		totalNumObjects := int64(0)
-		for sid, vdevs := range smap {
-			capacity := int64(0)
-			used := int64(0)
-			numObjects := int64(0)
-			for vdevid, vals := range vdevs {
-				if vals["state"] != "ONLINE" {
-					continue
-				}
-				for key, val := range vdmap[vdevid] {
-					if key == "capacity" {
-						v, err := strconv.ParseInt(val, 10, 64)
-						if err == nil {
-							capacity += v
-						}
-					} else if key == "used" {
-						v, err := strconv.ParseInt(val, 10, 64)
-						if err == nil {
-							used += v
-						}
-					} else if key == "num_objects" {
-						v, err := strconv.ParseInt(val, 10, 64)
-						if err == nil {
-							numObjects += v
-						}
+	totalCapacity := int64(0)
+	totalUsed := int64(0)
+	totalMdoffloadCapacity := int64(0)
+	totalMdoffloadUsed := int64(0)
+	totalS3offloadCapacity := int64(0)
+	totalS3offloadUsed := int64(0)
+	totalNumObjects := int64(0)
+	for sid, vdevs := range smap {
+		capacity := int64(0)
+		used := int64(0)
+		mdoffloadCapacity := int64(0)
+		mdoffloadUsed := int64(0)
+		s3offloadCapacity := int64(0)
+		s3offloadUsed := int64(0)
+
+		numObjects := int64(0)
+		for vdevid, vals := range vdevs {
+			if vals["state"] != "ONLINE" {
+				continue
+			}
+			if vdevid == "00000000000000000000000000000000" {
+				sdmap[sid]["gw"] = "1"
+				continue
+			}
+			for key, val := range vdmap[vdevid] {
+				if key == "capacity" {
+					v, err := strconv.ParseInt(val, 10, 64)
+					if err == nil {
+						capacity += v
+					}
+				} else if key == "used" {
+					v, err := strconv.ParseInt(val, 10, 64)
+					if err == nil {
+						used += v
+					}
+				} else if key == "num_objects" {
+					v, err := strconv.ParseInt(val, 10, 64)
+					if err == nil {
+						numObjects += v
+					}
+				} else if key == "mdoffload_total" {
+					v, err := strconv.ParseInt(val, 10, 64)
+					if err == nil {
+						mdoffloadCapacity += v
+					}
+				} else if key == "mdoffload_size" {
+					v, err := strconv.ParseInt(val, 10, 64)
+					if err == nil {
+						mdoffloadUsed += v
+					}
+				} else if key == "s3_offload_size" {
+					v, err := strconv.ParseInt(val, 10, 64)
+					if err == nil {
+						s3offloadCapacity += v
+					}
+				} else if key == "s3_offload_used" {
+					v, err := strconv.ParseInt(val, 10, 64)
+					if err == nil {
+						s3offloadUsed += v
 					}
 				}
 			}
-			sdmap[sid]["capacity"] = strconv.FormatInt(int64(capacity), 10)
-			sdmap[sid]["used"] = strconv.FormatInt(int64(used), 10)
-			sdmap[sid]["numObjects"] = strconv.FormatInt(int64(numObjects), 10)
-			totalCapacity += capacity
-			totalUsed += used
-			totalNumObjects += numObjects
 		}
-		totalAvailable := totalCapacity - totalUsed
-		totalUtilization := float64(100 * totalUsed / totalCapacity)
-		fmt.Printf("capacity %+v %+v\n", totalCapacity, sizefmt.ByteSize(float64(totalCapacity)))
-		fmt.Printf("used %+v %+v\n", totalUsed, sizefmt.ByteSize(float64(totalUsed)))
-		fmt.Printf("available %+v %+v\n", totalAvailable, sizefmt.ByteSize(float64(totalAvailable)))
-		fmt.Printf("utilization %+v %+v%%\n", totalUtilization, totalUtilization)
-		fmt.Printf("versions %+v %+vM\n", totalNumObjects, totalNumObjects / int64(1000000))
-		m, _ := readTrlogMarker()
-		if err != nil {
-			fmt.Printf("trlogmark err=%v\n", err)
-		} else if m > 0 && m != -1 {
-			cursec := time.Now().UnixNano() / 1000000000
-			fmt.Printf("trlogmark %+v -%+vs\n", m / int64(1000000), cursec - (m / int64(1000000)))
+		sdmap[sid]["capacity"] = strconv.FormatInt(int64(capacity), 10)
+		sdmap[sid]["used"] = strconv.FormatInt(int64(used), 10)
+		sdmap[sid]["mdoffload_capacity"] = strconv.FormatInt(int64(mdoffloadCapacity), 10)
+		sdmap[sid]["mdoffload_used"] = strconv.FormatInt(int64(mdoffloadUsed), 10)
+		sdmap[sid]["s3_offload_capacity"] = strconv.FormatInt(int64(s3offloadCapacity), 10)
+		sdmap[sid]["s3_offload_used"] = strconv.FormatInt(int64(s3offloadUsed), 10)
+
+		sdmap[sid]["numObjects"] = strconv.FormatInt(int64(numObjects), 10)
+		totalCapacity += capacity
+		totalUsed += used
+		totalNumObjects += numObjects
+		totalMdoffloadUsed += mdoffloadUsed
+		totalMdoffloadCapacity += mdoffloadCapacity
+		totalS3offloadCapacity += s3offloadCapacity
+		totalS3offloadUsed += s3offloadUsed
+
+		if isSummary {
+			totalAvailable := totalCapacity - totalUsed
+			totalUtilization := float64(100 * totalUsed / totalCapacity)
+			fmt.Printf("capacity %+v %+v\n", totalCapacity, sizefmt.ByteSize(float64(totalCapacity)))
+			fmt.Printf("used %+v %+v\n", totalUsed, sizefmt.ByteSize(float64(totalUsed)))
+			fmt.Printf("available %+v %+v\n", totalAvailable, sizefmt.ByteSize(float64(totalAvailable)))
+			fmt.Printf("utilization %+v %+v%%\n", totalUtilization, totalUtilization)
+			if totalMdoffloadCapacity > 0 {
+				fmt.Printf("MD ooffload capacity %+v %+v\n", totalMdoffloadCapacity, sizefmt.ByteSize(float64(totalMdoffloadCapacity)))
+				fmt.Printf("MD offload used %+v %+v\n", totalMdoffloadUsed, sizefmt.ByteSize(float64(totalMdoffloadUsed)))
+			}
+			if totalS3offloadCapacity > 0 {
+				fmt.Printf("S3 offload buckets capacity %+v %+v\n", totalS3offloadCapacity, sizefmt.ByteSize(float64(totalS3offloadCapacity)))
+				fmt.Printf("S3 offload buckets used %+v %+v\n", totalS3offloadUsed, sizefmt.ByteSize(float64(totalS3offloadUsed)))
+			}
+
+			fmt.Printf("versions %+v %+vM\n", totalNumObjects, totalNumObjects / int64(1000000))
+			m, _ := readTrlogMarker()
+			if err != nil {
+				fmt.Printf("trlogmark err=%v\n", err)
+			} else if m > 0 && m != -1 {
+				cursec := time.Now().UnixNano() / 1000000000
+				fmt.Printf("trlogmark %+v -%+vs\n", m / int64(1000000), cursec - (m / int64(1000000)))
+			}
+
+			conf, err := efsutil.GetLibccowConf()
+			if err != nil {
+				return err
+			}
+
+			c_conf := C.CString(string(conf))
+			defer C.free(unsafe.Pointer(c_conf))
+	
+			cl := C.CString("")
+			defer C.free(unsafe.Pointer(cl))
+
+			var tc C.ccow_t
+
+			ret := C.ccow_admin_init(c_conf, cl, 1, &tc)
+			if ret != 0 {
+				return fmt.Errorf("%s: ccow_admin_init err=%d", efsutil.GetFUNC(), ret)
+			}
+			defer C.ccow_tenant_term(tc)
+
+			guid := C.GoString(C.ccow_get_system_guid_formatted(tc))
+			fmt.Printf("guid %+s\n", guid);
+
+			segid := guid[0:16]
+			fmt.Printf("segid %+s\n", segid);
+			return nil
 		}
-
-		conf, err := efsutil.GetLibccowConf()
-		if err != nil {
-			return err
-		}
-
-		c_conf := C.CString(string(conf))
-		defer C.free(unsafe.Pointer(c_conf))
-
-		cl := C.CString("")
-		defer C.free(unsafe.Pointer(cl))
-
-		var tc C.ccow_t
-
-		ret := C.ccow_admin_init(c_conf, cl, 1, &tc)
-		if ret != 0 {
-			return fmt.Errorf("%s: ccow_admin_init err=%d", efsutil.GetFUNC(), ret)
-		}
-		defer C.ccow_tenant_term(tc)
-
-		guid := C.GoString(C.ccow_get_system_guid_formatted(tc))
-		fmt.Printf("guid %+s\n", guid);
-
-		segid := guid[0:16]
-		fmt.Printf("segid %+s\n", segid);
-		return nil
 	}
 
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetBorder(false)
+	table.SetAlignment(tablewriter.ALIGN_CENTER)
+	hdr := []string{"SID","HOST","POD"}
+	if verbose > 0 {
+		hdr = append(hdr, "VDEV", "DISK")
+	}
+	hdr = append(hdr, "USED,%")
+	if totalMdoffloadCapacity > 0 {
+		hdr = append(hdr, "MDUSED,%")
+	}
+	if totalS3offloadCapacity > 0 {
+		hdr = append(hdr, "S3USED,%")
+	}
+	hdr = append(hdr, "STATE")
+	table.SetHeader(hdr)
+	sidPrev := ""
 	for sid, vdevs := range smap {
+		_, gw := sdmap[sid]["gw"]
+		contID := "N/A"
+		if _, ok := sdmap[sid]["containerid"]; ok && len(sdmap[sid]["containerid"]) > 0 {
+			contID = sdmap[sid]["containerid"]
+		}
+		hostName := sdmap[sid]["hostname"]
 		state := "ONLINE"
 		vdevOfflineCount := 0
 		vdevReadOnlyCount := 0
@@ -413,23 +503,117 @@ func SystemStatus(isSummary bool) error {
 				vdevReadOnlyCount++
 			}
 		}
-
 		if vdevOfflineCount == len(vdevs) {
 			state = "FAULTED"
 		} else if vdevOfflineCount > 0 || vdevReadOnlyCount > 0 {
 			state = "DEGRADED"
 		}
+		if verbose == 0 {
+			row := []string{sid, hostName, contID}
+			// Output target-related information only
+			util, mdutil, s3util := 0, 0, 0
+			used,_ := strconv.Atoi(sdmap[sid]["used"])
+			capacity,_ := strconv.Atoi(sdmap[sid]["capacity"])
+			if capacity > 0 {
+				util = 10000 * used / capacity
+			}
 
-		if contId, ok := sdmap[sid]["containerid"]; ok {
-			fmt.Printf("ServerID %s %s:%s %s\n", sid, sdmap[sid]["hostname"], contId, state)
-		} else {
-			fmt.Printf("ServerID %s %s %s\n", sid, sdmap[sid]["hostname"], state)
-		}
-		if verbose > 0 {
-			if verbose > 1 {
-				for key, val := range sdmap[sid] {
-					fmt.Printf("  - %s %+v\n", key, val)
+			if _, ok := sdmap[sid]["mdoffload_capacity"]; ok && totalMdoffloadCapacity > 0 {
+				c,_ := strconv.Atoi(sdmap[sid]["mdoffload_capacity"])
+				u,_ := strconv.Atoi(sdmap[sid]["mdoffload_used"])
+				if c > 0 {
+					mdutil = 10000 * u / c
 				}
+			}
+			if _, ok := sdmap[sid]["s3_offload_capacity"]; ok && totalS3offloadCapacity > 0 {
+				c,_ := strconv.Atoi(sdmap[sid]["s3_offload_capacity"])
+				u,_ := strconv.Atoi(sdmap[sid]["s3_offload_used"])
+				if c > 0 {
+					s3util = 10000 * u / c
+				}
+			}
+			if gw {
+				row = append(row, "N/A")
+			} else {
+				row = append(row, strconv.FormatFloat(float64(util)/100.0, 'f', 2, 64))
+			}
+			if totalMdoffloadCapacity > 0 {
+				if gw {
+					row = append(row, "N/A")
+				} else {
+					row = append(row, strconv.FormatFloat(float64(mdutil)/100.0, 'f', 2, 64))
+				}
+			}
+			if totalS3offloadCapacity > 0 {
+				if gw {
+					row = append(row, "N/A")
+				} else {
+					row = append(row, strconv.FormatFloat(float64(s3util)/100.0, 'f', 2, 64))
+				}
+			}
+			row = append(row, state)
+			table.Append(row)
+		} else if verbose == 1 {
+			if gw {
+				row := []string{sid, hostName, contID, "-", "-", "N/A"};
+				if totalMdoffloadCapacity > 0 {
+					row = append(row, "N/A")
+				}
+				if totalS3offloadCapacity > 0 {
+					row = append(row, "N/A")
+				}
+				row = append(row, state)
+				table.Append(row)
+				continue
+			}
+			for vdevid, vals := range vdevs {
+				util, mdutil, s3util := 0,0,0
+				used,_ := strconv.Atoi(vdmap[vdevid]["used"])
+				capacity,_ := strconv.Atoi(vdmap[vdevid]["capacity"])
+				if capacity > 0 {
+					util = 10000 * used/capacity
+				}
+				if _, ok := vdmap[vdevid]["mdoffload_total"]; ok && totalMdoffloadCapacity > 0 {
+					c,_ := strconv.Atoi(vdmap[vdevid]["mdoffload_total"])
+					u,_ := strconv.Atoi(vdmap[vdevid]["mdoffload_used"])
+					if c > 0 {
+						mdutil = 10000 * u / c
+					}
+				}
+				if _, ok := vdmap[vdevid]["s3_offload_size"]; ok && totalS3offloadCapacity > 0 {
+					c,_ := strconv.Atoi(vdmap[vdevid]["s3_offload_size"])
+					u,_ := strconv.Atoi(vdmap[vdevid]["s3_offload_used"])
+					if c > 0 {
+						s3util = 10000 * u / c
+					}
+				}
+				row := []string{}
+				if sidPrev != sid {
+					row = []string{sid, hostName, contID, vdevid, vdmap[vdevid]["devname"],
+						strconv.FormatFloat(float64(util)/100.0, 'f', 2, 64)}
+				} else {
+					row = []string{"", "", "", vdevid, vdmap[vdevid]["devname"],
+						strconv.FormatFloat(float64(util)/100.0, 'f', 2, 64)}
+				}
+				sidPrev = sid
+				if totalMdoffloadCapacity > 0 {
+					row = append(row, strconv.FormatFloat(float64(mdutil)/100.0, 'f', 2, 64))
+				}
+				if totalS3offloadCapacity > 0 {
+					row = append(row, strconv.FormatFloat(float64(s3util)/100.0, 'f', 2, 64))
+				}
+				row = append(row, vals["state"])
+				table.Append(row)
+			}
+		} else {
+			if contId, ok := sdmap[sid]["containerid"]; ok {
+				fmt.Printf("ServerID %s %s:%s %s\n", sid, sdmap[sid]["hostname"], contId, state)
+			} else {
+				fmt.Printf("ServerID %s %s %s\n", sid, sdmap[sid]["hostname"], state)
+			}
+
+			for key, val := range sdmap[sid] {
+				fmt.Printf("  - %s %+v\n", key, val)
 			}
 			for vdevid, vals := range vdevs {
 				// Don not show GW's pseudo VDEV
@@ -437,13 +621,16 @@ func SystemStatus(isSummary bool) error {
 					continue
 				}
 				fmt.Printf("  VDEVID %s %s %s\n", vdevid, vdmap[vdevid]["devname"], vals["state"])
-				if verbose > 2 {
-					for key, val := range vdmap[vdevid] {
-						fmt.Printf("    - %s %+v\n", key, val)
-					}
+				for key, val := range vdmap[vdevid] {
+					fmt.Printf("    - %s %+v\n", key, val)
 				}
 			}
 		}
+	}
+	if verbose <= 1 {
+		fmt.Println()
+		table.Render()
+		fmt.Println()
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
1. RTRD: gather S3 payload statistics separately. Publish it by auditc
2. efscli system status: show utilization statistics for main store, MD store and S3 payload

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
