### PR TITLE
Corosync: set mtu=1400 and use udpu network engine

### DIFF
--- a/deps/corosync/corosync.conf.example.ipv4
+++ b/deps/corosync/corosync.conf.example.ipv4
@@ -125,7 +125,7 @@ totem {
 	max_messages: 15
 
 	# Unicast discovery, ring0 node table required!
-	transport: knet
+	transport: udpu
 }
  
 # This directive controls how Corosync logs it's messages. All variables here

--- a/src/efscli/config/config.go
+++ b/src/efscli/config/config.go
@@ -281,9 +281,8 @@ func ConfigNode() {
 			// adjust log file location
 			output := regexp.MustCompile(`/opt/nedge`).ReplaceAllString(string(input), os.Getenv("NEDGE_HOME"))
 	
-			// adjust netmtu to the current value of selected server interface name
-			ifname0 := strings.Split(nodeConfig.Ccowd.Network.ServerInterfaces, ";")[0]
-			netmtu := DetectMTU(ifname0)
+			// Use the smallest possible MTU value
+			netmtu := 1400
 			output = regexp.MustCompile(`netmtu:.*`).ReplaceAllString(output, "netmtu: "+strconv.Itoa(netmtu))
 	
 			if err = ioutil.WriteFile(nedgeHome+CorosyncConfFile, []byte(output), 0666); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
corosync default configuration changed as follow:
1. Use fixed mtu=1400
2. Use the UDPU network engine


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
