### PR TITLE
Expose interface to used malloc/free methods, so caller can allocate …

### DIFF
--- a/src/ccow/include/ccowfsio.h
+++ b/src/ccow/include/ccowfsio.h
@@ -147,6 +147,14 @@ ci_t *ccow_fsio_ci_alloc(void);
 /* Free ci structure. */
 void ccow_fsio_ci_free(ci_t *);
 
+/*
+ * Generic memory management interface.
+ * Used for clients that run with different allocator. So it can allocate memory
+ * that will be freed by ccowfsio and free that allocated by ccowfsio.
+ */
+void *ccow_fsio_mem_alloc(size_t size);
+void ccow_fsio_mem_free(void *ptr);
+
 /**
  * FSIO init
  * Must be called just after the lib is loaded

--- a/src/ccow/src/libccowfsio/fsio_system.c
+++ b/src/ccow/src/libccowfsio/fsio_system.c
@@ -943,6 +943,20 @@ ccow_fsio_ci_alloc()
 	return (ci);
 }
 
+void *
+ccow_fsio_mem_alloc(size_t size)
+{
+
+	return (je_malloc(size));
+}
+
+void
+ccow_fsio_mem_free(void *ptr)
+{
+
+	return (je_free(ptr));
+}
+
 void
 ccow_fsio_ci_free(ci_t * ci)
 {


### PR DESCRIPTION
…memory that CCOW will free.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first PR, read our contributor guidelines http://edgefs.io/contribute/
2. Follow these instructions to write commit messages http://karma-runner.github.io/3.0/dev/git-commit-msg.html
3. Follow these instructions to write tests https://edgefs.io/contribute/development/#testing
4. You can trigger the tests for your PR with /test bdd
5. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Change modifies documentation or comments only.

#### Description
samba, when doing write to file, give buffer allocated by own talloc allocater. But ccowfsio want to free passed buffer using jemalloc or asan methods. So we need a way to allocate buffer before pass it to ccowfsio write method. 

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #

<!--
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged
-->
